### PR TITLE
Refactor bottom navigation bar into a standalone component

### DIFF
--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/AppNavigation.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/AppNavigation.kt
@@ -1,28 +1,7 @@
 package com.app.douyin.pro.navigation
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.Icon
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.NavigationBarItemDefaults
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -106,73 +85,3 @@ fun AppNavHost(
     }
 }
 
-@Composable
-fun MainBottomBar(
-    currentRoute: String?,
-    onNavigate: (String) -> Unit
-) {
-    val isDarkBgRoute = NavigationConfigs.isDarkBackgroundRoute(currentRoute)
-
-    NavigationBar(
-        containerColor = if (isDarkBgRoute) Color.Transparent else Color.White,
-        contentColor = if (isDarkBgRoute) Color.White else Color.Black
-    ) {
-        MainTab.items.forEach { item ->
-            val isSelected = currentRoute == item.route
-            NavigationBarItem(
-                icon = {
-                    if (item == MainTab.Record) {
-                        RecordIcon()
-                    } else {
-                        item.icon?.let { Icon(it, contentDescription = item.title, modifier = Modifier.padding(bottom = 2.dp)) }
-                    }
-                },
-                label = {
-                    if (item != MainTab.Record) {
-                        Text(
-                            text = item.title,
-                            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-                            fontSize = 10.sp
-                        )
-                    }
-                },
-                selected = isSelected,
-                colors = NavigationBarItemDefaults.colors(
-                    selectedIconColor = if (isDarkBgRoute) Color.White else Color.Black,
-                    unselectedIconColor = Color.LightGray,
-                    selectedTextColor = if (isDarkBgRoute) Color.White else Color.Black,
-                    unselectedTextColor = Color.LightGray,
-                    indicatorColor = Color.Transparent
-                ),
-                onClick = { onNavigate(item.route) }
-            )
-        }
-    }
-}
-
-@Composable
-private fun RecordIcon() {
-    Box(
-        modifier = Modifier
-            .width(44.dp)
-            .height(30.dp)
-            .clip(RoundedCornerShape(8.dp))
-            .drawBehind {
-                drawRoundRect(
-                    brush = Brush.horizontalGradient(
-                        colors = listOf(Color(0xFF00E5FF), Color(0xFFFF0050))
-                    ),
-                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(8.dp.toPx())
-                )
-                drawRoundRect(
-                    color = Color.White,
-                    size = androidx.compose.ui.geometry.Size(size.width - 8.dp.toPx(), size.height),
-                    topLeft = androidx.compose.ui.geometry.Offset(4.dp.toPx(), 0f),
-                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(8.dp.toPx())
-                )
-            },
-        contentAlignment = Alignment.Center
-    ) {
-        Icon(Icons.Filled.Add, contentDescription = "拍摄", tint = Color.Black)
-    }
-}

--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/MainBottomBar.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/MainBottomBar.kt
@@ -1,0 +1,116 @@
+package com.app.douyin.pro.navigation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun MainBottomBar(
+    currentRoute: String?,
+    onNavigate: (String) -> Unit
+) {
+    val isDarkBgRoute = NavigationConfigs.isDarkBackgroundRoute(currentRoute)
+
+    NavigationBar(
+        containerColor = if (isDarkBgRoute) Color.Transparent else Color.White,
+        contentColor = if (isDarkBgRoute) Color.White else Color.Black,
+        tonalElevation = 0.dp
+    ) {
+        MainTab.items.forEach { item ->
+            val isSelected = currentRoute == item.route
+            NavigationBarItem(
+                icon = {
+                    if (item == MainTab.Record) {
+                        RecordIcon()
+                    } else {
+                        BadgedBox(
+                            badge = {
+                                if (item.badgeCount > 0) {
+                                    Badge {
+                                        Text(item.badgeCount.toString())
+                                    }
+                                } else if (item.showDot) {
+                                    Badge()
+                                }
+                            }
+                        ) {
+                            item.icon?.let {
+                                Icon(
+                                    it,
+                                    contentDescription = item.title,
+                                    modifier = Modifier.padding(bottom = 2.dp)
+                                )
+                            }
+                        }
+                    }
+                },
+                label = {
+                    if (item != MainTab.Record) {
+                        Text(
+                            text = item.title,
+                            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                            fontSize = 10.sp
+                        )
+                    }
+                },
+                selected = isSelected,
+                colors = NavigationBarItemDefaults.colors(
+                    selectedIconColor = if (isDarkBgRoute) Color.White else Color.Black,
+                    unselectedIconColor = Color.LightGray,
+                    selectedTextColor = if (isDarkBgRoute) Color.White else Color.Black,
+                    unselectedTextColor = Color.LightGray,
+                    indicatorColor = Color.Transparent
+                ),
+                onClick = { onNavigate(item.route) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecordIcon() {
+    Box(
+        modifier = Modifier
+            .width(44.dp)
+            .height(30.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .drawBehind {
+                drawRoundRect(
+                    brush = Brush.horizontalGradient(
+                        colors = listOf(Color(0xFF00E5FF), Color(0xFFFF0050))
+                    ),
+                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(8.dp.toPx())
+                )
+                drawRoundRect(
+                    color = Color.White,
+                    size = androidx.compose.ui.geometry.Size(size.width - 8.dp.toPx(), size.height),
+                    topLeft = androidx.compose.ui.geometry.Offset(4.dp.toPx(), 0f),
+                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(8.dp.toPx())
+                )
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(Icons.Filled.Add, contentDescription = "拍摄", tint = Color.Black)
+    }
+}

--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/MainTab.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/MainTab.kt
@@ -9,7 +9,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 sealed class MainTab(
     val route: String,
     val title: String,
-    val icon: ImageVector?
+    val icon: ImageVector?,
+    val badgeCount: Int = 0,
+    val showDot: Boolean = false
 ) {
     data object Home : MainTab(NavRoutes.HOME, "首页", Icons.Filled.Home)
     data object Friends : MainTab(NavRoutes.FRIENDS, "朋友", Icons.Filled.Person)
@@ -19,5 +21,9 @@ sealed class MainTab(
 
     companion object {
         val items = listOf(Home, Friends, Record, Inbox, Me)
+
+        fun fromRoute(route: String?): MainTab? {
+            return items.find { it.route == route }
+        }
     }
 }


### PR DESCRIPTION
The bottom navigation bar has been refactored into a standalone component to improve maintainability and extensibility. 

Key changes:
- `MainBottomBar` and its helper `RecordIcon` are now in `DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/MainBottomBar.kt`.
- `MainTab` now includes `badgeCount` and `showDot` properties for future notification/unread indicators.
- Added `MainTab.fromRoute(route)` helper for easier route-to-tab mapping.
- `MainBottomBar` uses Material 3 `BadgedBox` to render badges.
- `AppNavigation.kt` was cleaned up by removing the extracted UI logic.
- Verified the build and ran all existing unit tests successfully.
- Removed temporary build artifacts before submission.

Fixes #38

---
*PR created automatically by Jules for task [10408952990914449438](https://jules.google.com/task/10408952990914449438) started by @zx2121651*