### PR TITLE
Refactor Home state management to unified UI State model

### DIFF
--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/HomeScreen.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/HomeScreen.kt
@@ -32,6 +32,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.app.douyin.pro.feature.home.ui.components.*
 import com.app.douyin.pro.feature.home.ui.components.CommentsBottomSheet
 import com.app.douyin.pro.feature.home.viewmodel.HomeViewModel
+import com.app.douyin.pro.feature.home.viewmodel.LoadState
+import com.app.douyin.pro.feature.home.viewmodel.PagingState
 import com.app.douyin.pro.feature.home.domain.model.VideoModel
 import kotlinx.coroutines.launch
 import java.util.*
@@ -42,9 +44,7 @@ fun HomeScreen(
     onNavigateToProfile: () -> Unit = {},
     viewModel: HomeViewModel = hiltViewModel()
 ) {
-    val videos = viewModel.videos
-    val isLoading by viewModel.isLoading.collectAsState()
-    val error by viewModel.error.collectAsState()
+    val uiState by viewModel.uiState.collectAsState()
     val coroutineScope = rememberCoroutineScope()
     val horizontalPagerState = rememberPagerState(initialPage = 3, pageCount = { 4 })
     val selectedTopTabIndex = horizontalPagerState.currentPage + 1
@@ -56,44 +56,148 @@ fun HomeScreen(
         return
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
-        if (isLoading && videos.isEmpty()) {
-            Box(modifier = Modifier.fillMaxSize().background(Color.Black), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator(color = Color(0xFFFF2C55))
-            }
-        } else if (error != null && videos.isEmpty()) {
-            Box(modifier = Modifier.fillMaxSize().background(Color.Black), contentAlignment = Alignment.Center) {
-                Text(text = "加载失败: ", color = Color.White)
-            }
-        } else {
-            HorizontalPager(
-                state = horizontalPagerState,
-                modifier = Modifier.fillMaxSize()
-            ) { page ->
-                when (page) {
-                    0 -> LiveScreen()
-                    1 -> { /* Place for Local Screen */ }
-                    2 -> VideoFeed(videos = videos.reversed(), isVisible = horizontalPagerState.currentPage == 2, onNavigateToProfile = onNavigateToProfile)
-                    3 -> VideoFeed(videos = videos, isVisible = horizontalPagerState.currentPage == 3, onNavigateToProfile = onNavigateToProfile)
+    Box(modifier = Modifier.fillMaxSize().background(Color.Black)) {
+        when (val loadState = uiState.loadState) {
+            is LoadState.Loading -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(color = Color(0xFFFF2C55))
                 }
             }
-
-            AnimatedVisibility(
-                visible = horizontalPagerState.currentPage != 0,
-                enter = fadeIn(),
-                exit = fadeOut(),
-                modifier = Modifier.align(Alignment.TopCenter)
-            ) {
-                TopNavigationBar(
-                    selectedTabIndex = selectedTopTabIndex,
-                    onTabSelected = { index ->
-                        coroutineScope.launch { horizontalPagerState.animateScrollToPage(index) }
-                    },
-                    onSearchClick = { showSearchScreen = true },
-                    onNavigateToMall = onNavigateToMall,
-                    modifier = Modifier.statusBarsPadding()
+            is LoadState.Error -> {
+                ErrorView(
+                    message = loadState.message,
+                    onRetry = { viewModel.loadInitialData() }
                 )
             }
+            is LoadState.Success -> {
+                if (loadState.isEmpty) {
+                    EmptyView(onRetry = { viewModel.loadInitialData() })
+                } else {
+                    HomeContent(
+                        uiState = uiState,
+                        horizontalPagerState = horizontalPagerState,
+                        coroutineScope = coroutineScope,
+                        onNavigateToMall = onNavigateToMall,
+                        onNavigateToProfile = onNavigateToProfile,
+                        onSearchClick = { showSearchScreen = true },
+                        onLoadMore = { viewModel.loadMore() }
+                    )
+                }
+            }
+            else -> {}
+        }
+    }
+}
+
+@Composable
+private fun HomeContent(
+    uiState: com.app.douyin.pro.feature.home.viewmodel.HomeUiState,
+    horizontalPagerState: androidx.compose.foundation.pager.PagerState,
+    coroutineScope: kotlinx.coroutines.CoroutineScope,
+    onNavigateToMall: () -> Unit,
+    onNavigateToProfile: () -> Unit,
+    onSearchClick: () -> Unit,
+    onLoadMore: () -> Unit
+) {
+    val selectedTopTabIndex = horizontalPagerState.currentPage + 1
+    Box(modifier = Modifier.fillMaxSize()) {
+        HorizontalPager(
+            state = horizontalPagerState,
+            modifier = Modifier.fillMaxSize()
+        ) { page ->
+            when (page) {
+                0 -> LiveScreen()
+                1 -> { /* Place for Local Screen */ }
+                2 -> VideoFeed(
+                    videos = uiState.videos.reversed(),
+                    isVisible = horizontalPagerState.currentPage == 2,
+                    onNavigateToProfile = onNavigateToProfile,
+                    pagingState = uiState.pagingState,
+                    onLoadMore = onLoadMore
+                )
+                3 -> VideoFeed(
+                    videos = uiState.videos,
+                    isVisible = horizontalPagerState.currentPage == 3,
+                    onNavigateToProfile = onNavigateToProfile,
+                    pagingState = uiState.pagingState,
+                    onLoadMore = onLoadMore
+                )
+            }
+        }
+
+        AnimatedVisibility(
+            visible = horizontalPagerState.currentPage != 0,
+            enter = fadeIn(),
+            exit = fadeOut(),
+            modifier = Modifier.align(Alignment.TopCenter)
+        ) {
+            TopNavigationBar(
+                selectedTabIndex = selectedTopTabIndex,
+                onTabSelected = { index ->
+                    coroutineScope.launch { horizontalPagerState.animateScrollToPage(index) }
+                },
+                onSearchClick = onSearchClick,
+                onNavigateToMall = onNavigateToMall,
+                modifier = Modifier.statusBarsPadding()
+            )
+        }
+    }
+}
+
+@Composable
+fun ErrorView(message: String, onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            Icons.Filled.Warning,
+            contentDescription = null,
+            tint = Color.Gray,
+            modifier = Modifier.size(64.dp)
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "加载失败: $message",
+            color = Color.White,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(
+            onClick = onRetry,
+            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF2C55))
+        ) {
+            Text("重试")
+        }
+    }
+}
+
+@Composable
+fun EmptyView(onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            Icons.Filled.Info,
+            contentDescription = null,
+            tint = Color.Gray,
+            modifier = Modifier.size(64.dp)
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "暂无视频内容",
+            color = Color.White,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(
+            onClick = onRetry,
+            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF2C55))
+        ) {
+            Text("刷新")
         }
     }
 }

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/components/VideoFeed.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/components/VideoFeed.kt
@@ -1,10 +1,15 @@
 package com.app.douyin.pro.feature.home.ui.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
@@ -13,7 +18,12 @@ import com.app.douyin.pro.feature.home.domain.model.VideoModel
 
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.app.douyin.pro.feature.home.viewmodel.PagingState
 import com.app.douyin.pro.lib.media.VideoPlayerManager
 
 
@@ -22,7 +32,9 @@ import com.app.douyin.pro.lib.media.VideoPlayerManager
 fun VideoFeed(
     videos: List<VideoModel>,
     isVisible: Boolean,
-    onNavigateToProfile: () -> Unit
+    onNavigateToProfile: () -> Unit,
+    pagingState: PagingState = PagingState.Idle,
+    onLoadMore: () -> Unit = {}
 ) {
     val pagerState = rememberPagerState(pageCount = { videos.size })
     val context = LocalContext.current
@@ -34,24 +46,76 @@ fun VideoFeed(
         if (nextIndex < videos.size) {
             playerManager.preLoad(videos[nextIndex].playUrl)
         }
+
+        // Trigger load more when reaching near the end
+        if (pagerState.currentPage >= videos.size - 2 && videos.isNotEmpty()) {
+            onLoadMore()
+        }
     }
 
-    VerticalPager(
-        state = pagerState,
-        beyondBoundsPageCount = 1,
-        modifier = Modifier
-            .fillMaxSize()
-            .pointerInput(Unit) {
-                detectHorizontalDragGestures { _, dragAmount ->
-                    if (dragAmount < -30f) {
-                        onNavigateToProfile()
+    Box(modifier = Modifier.fillMaxSize()) {
+        VerticalPager(
+            state = pagerState,
+            beyondBoundsPageCount = 1,
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    detectHorizontalDragGestures { _, dragAmount ->
+                        if (dragAmount < -30f) {
+                            onNavigateToProfile()
+                        }
                     }
                 }
+        ) { vPage ->
+            VideoPage(
+                video = videos[vPage],
+                isVisible = isVisible && pagerState.currentPage == vPage
+            )
+        }
+
+        // Pagination status overlay at the bottom
+        if (pagingState !is PagingState.Idle) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 80.dp) // Avoid overlap with bottom bar
+                    .padding(16.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                when (pagingState) {
+                    is PagingState.Loading -> {
+                        CircularProgressIndicator(
+                            color = Color.White.copy(alpha = 0.5f),
+                            modifier = Modifier.size(24.dp),
+                            strokeWidth = 2.dp
+                        )
+                    }
+                    is PagingState.Error -> {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .background(Color.Black.copy(alpha = 0.6f), MaterialTheme.shapes.small)
+                                .padding(horizontal = 12.dp, vertical = 6.dp)
+                        ) {
+                            Text(
+                                text = "加载更多失败",
+                                color = Color.White,
+                                fontSize = 12.sp
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            TextButton(
+                                onClick = onLoadMore,
+                                contentPadding = PaddingValues(0.dp),
+                                modifier = Modifier.heightIn(min = 24.dp)
+                            ) {
+                                Text("重试", color = Color(0xFFFF2C55), fontSize = 12.sp)
+                            }
+                        }
+                    }
+                    else -> {}
+                }
             }
-    ) { vPage ->
-        VideoPage(
-            video = videos[vPage],
-            isVisible = isVisible && pagerState.currentPage == vPage
-        )
+        }
     }
 }

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/HomeViewModel.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/HomeViewModel.kt
@@ -15,6 +15,25 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+sealed class LoadState {
+    object Idle : LoadState()
+    object Loading : LoadState()
+    data class Success(val isEmpty: Boolean) : LoadState()
+    data class Error(val message: String) : LoadState()
+}
+
+sealed class PagingState {
+    object Idle : PagingState()
+    object Loading : PagingState()
+    data class Error(val message: String) : PagingState()
+}
+
+data class HomeUiState(
+    val videos: List<VideoModel> = emptyList(),
+    val loadState: LoadState = LoadState.Idle,
+    val pagingState: PagingState = PagingState.Idle
+)
+
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val getVideosUseCase: GetVideosUseCase,
@@ -22,14 +41,8 @@ class HomeViewModel @Inject constructor(
     private val apiService: DouyinApiService
 ) : ViewModel() {
 
-    private val _videos = mutableStateListOf<VideoModel>()
-    val videos: List<VideoModel> = _videos
-
-    private val _isLoading = MutableStateFlow(false)
-    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
-
-    private val _error = MutableStateFlow<String?>(null)
-    val error: StateFlow<String?> = _error.asStateFlow()
+    private val _uiState = MutableStateFlow(HomeUiState())
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
     private var pageCount = 1
 
@@ -37,47 +50,69 @@ class HomeViewModel @Inject constructor(
         loadInitialData()
     }
 
-    private fun loadInitialData() {
+    fun loadInitialData() {
         viewModelScope.launch {
-            _isLoading.value = true
-            _error.value = null
+            _uiState.value = _uiState.value.copy(loadState = LoadState.Loading)
             when (val result = getVideosUseCase()) {
-                is Resource.Success -> _videos.addAll(result.data)
-                is Resource.Error -> _error.value = result.message
-                else -> {}
+                is Resource.Success -> {
+                    _uiState.value = _uiState.value.copy(
+                        videos = result.data,
+                        loadState = LoadState.Success(isEmpty = result.data.isEmpty())
+                    )
+                    pageCount = 1
+                }
+                is Resource.Error -> {
+                    _uiState.value = _uiState.value.copy(
+                        loadState = LoadState.Error(result.message)
+                    )
+                }
+                else -> {
+                    _uiState.value = _uiState.value.copy(loadState = LoadState.Idle)
+                }
             }
-            _isLoading.value = false
         }
     }
 
     fun loadMore() {
-        if (_isLoading.value) return
+        if (_uiState.value.pagingState is PagingState.Loading) return
 
         viewModelScope.launch {
-            _isLoading.value = true
+            _uiState.value = _uiState.value.copy(pagingState = PagingState.Loading)
             when (val result = loadMoreVideosUseCase(pageCount)) {
                 is Resource.Success -> {
-                    _videos.addAll(result.data)
+                    val currentVideos = _uiState.value.videos.toMutableList()
+                    currentVideos.addAll(result.data)
+                    _uiState.value = _uiState.value.copy(
+                        videos = currentVideos,
+                        pagingState = PagingState.Idle
+                    )
                     pageCount++
                 }
-                is Resource.Error -> _error.value = result.message
-                else -> {}
+                is Resource.Error -> {
+                    _uiState.value = _uiState.value.copy(
+                        pagingState = PagingState.Error(result.message)
+                    )
+                }
+                else -> {
+                    _uiState.value = _uiState.value.copy(pagingState = PagingState.Idle)
+                }
             }
-            _isLoading.value = false
         }
     }
 
     fun toggleLike(videoId: Long) {
-        val index = _videos.indexOfFirst { it.id == videoId }
+        val currentVideos = _uiState.value.videos.toMutableList()
+        val index = currentVideos.indexOfFirst { it.id == videoId }
         if (index != -1) {
-            val video = _videos[index]
+            val video = currentVideos[index]
             val newIsLiked = !video.isLiked
 
             // Optimistic update
-            _videos[index] = video.copy(
+            currentVideos[index] = video.copy(
                 isLiked = newIsLiked,
                 likeCount = adjustCount(video.likeCount, if (newIsLiked) 1 else -1)
             )
+            _uiState.value = _uiState.value.copy(videos = currentVideos)
 
             // Send to backend
             viewModelScope.launch {
@@ -85,14 +120,21 @@ class HomeViewModel @Inject constructor(
                     val actionType = if (newIsLiked) 1 else 2
                     val response = apiService.favoriteAction(videoId, actionType)
                     if (response.statusCode != 0) {
-                        // Revert on failure
-                        _videos[index] = video
+                        revertLike(videoId, video)
                     }
                 } catch (e: Exception) {
-                    // Revert on failure
-                    _videos[index] = video
+                    revertLike(videoId, video)
                 }
             }
+        }
+    }
+
+    private fun revertLike(videoId: Long, originalVideo: VideoModel) {
+        val currentVideos = _uiState.value.videos.toMutableList()
+        val index = currentVideos.indexOfFirst { it.id == videoId }
+        if (index != -1) {
+            currentVideos[index] = originalVideo
+            _uiState.value = _uiState.value.copy(videos = currentVideos)
         }
     }
 
@@ -107,24 +149,35 @@ class HomeViewModel @Inject constructor(
     }
 
     fun toggleFollow(videoId: Long) {
-        val index = _videos.indexOfFirst { it.id == videoId }
+        val currentVideos = _uiState.value.videos.toMutableList()
+        val index = currentVideos.indexOfFirst { it.id == videoId }
         if (index != -1) {
-            val video = _videos[index]
+            val video = currentVideos[index]
             val newIsFollowed = !video.isFollowed
 
-            _videos[index] = video.copy(isFollowed = newIsFollowed)
+            currentVideos[index] = video.copy(isFollowed = newIsFollowed)
+            _uiState.value = _uiState.value.copy(videos = currentVideos)
 
             viewModelScope.launch {
                 try {
                     val actionType = if (newIsFollowed) 1 else 2
                     val response = apiService.relationAction(video.authorId, actionType)
                     if (response.statusCode != 0) {
-                        _videos[index] = video // revert on failure
+                        revertFollow(videoId, video)
                     }
                 } catch (e: Exception) {
-                    _videos[index] = video // revert on failure
+                    revertFollow(videoId, video)
                 }
             }
+        }
+    }
+
+    private fun revertFollow(videoId: Long, originalVideo: VideoModel) {
+        val currentVideos = _uiState.value.videos.toMutableList()
+        val index = currentVideos.indexOfFirst { it.id == videoId }
+        if (index != -1) {
+            currentVideos[index] = originalVideo
+            _uiState.value = _uiState.value.copy(videos = currentVideos)
         }
     }
 }

--- a/DouyinLite/feature_home/src/test/java/com/app/douyin/pro/feature/home/viewmodel/HomeViewModelTest.kt
+++ b/DouyinLite/feature_home/src/test/java/com/app/douyin/pro/feature/home/viewmodel/HomeViewModelTest.kt
@@ -1,0 +1,103 @@
+package com.app.douyin.pro.feature.home.viewmodel
+
+import com.app.douyin.pro.feature.home.domain.model.VideoModel
+import com.app.douyin.pro.feature.home.domain.usecase.GetVideosUseCase
+import com.app.douyin.pro.feature.home.domain.usecase.LoadMoreVideosUseCase
+import com.app.douyin.pro.lib.media.model.Resource
+import com.app.douyin.pro.lib.media.network.DouyinApiService
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class HomeViewModelTest {
+
+    private lateinit var viewModel: HomeViewModel
+    private val getVideosUseCase: GetVideosUseCase = mock(GetVideosUseCase::class.java)
+    private val loadMoreVideosUseCase: LoadMoreVideosUseCase = mock(LoadMoreVideosUseCase::class.java)
+    private val apiService: DouyinApiService = mock(DouyinApiService::class.java)
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `loadInitialData success updates state with videos`() = runTest {
+        val videos = listOf(VideoModel(1, "title", "author", "authorAvatar", 101, "playUrl", "coverUrl", "100", "50", "10", false, false))
+        `when`(getVideosUseCase()).thenReturn(Resource.Success(videos))
+
+        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, apiService)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.loadState is LoadState.Success)
+        assertEquals(videos, state.videos)
+        assertEquals(false, (state.loadState as LoadState.Success).isEmpty)
+    }
+
+    @Test
+    fun `loadInitialData failure updates state with error`() = runTest {
+        val errorMessage = "Network Error"
+        `when`(getVideosUseCase()).thenReturn(Resource.Error(errorMessage))
+
+        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, apiService)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.loadState is LoadState.Error)
+        assertEquals(errorMessage, (state.loadState as LoadState.Error).message)
+    }
+
+    @Test
+    fun `loadMore success appends videos to state`() = runTest {
+        val initialVideos = listOf(VideoModel(1, "v1", "a1", "av1", 101, "p1", "c1", "1", "1", "1", false, false))
+        val moreVideos = listOf(VideoModel(2, "v2", "a2", "av2", 102, "p2", "c2", "2", "2", "2", false, false))
+        `when`(getVideosUseCase()).thenReturn(Resource.Success(initialVideos))
+        `when`(loadMoreVideosUseCase(1)).thenReturn(Resource.Success(moreVideos))
+
+        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, apiService)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.loadMore()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(2, state.videos.size)
+        assertEquals(initialVideos + moreVideos, state.videos)
+        assertTrue(state.pagingState is PagingState.Idle)
+    }
+
+    @Test
+    fun `loadMore failure updates pagingState with error`() = runTest {
+        val initialVideos = listOf(VideoModel(1, "v1", "a1", "av1", 101, "p1", "c1", "1", "1", "1", false, false))
+        val errorMessage = "Paging Error"
+        `when`(getVideosUseCase()).thenReturn(Resource.Success(initialVideos))
+        `when`(loadMoreVideosUseCase(1)).thenReturn(Resource.Error(errorMessage))
+
+        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, apiService)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.loadMore()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(1, state.videos.size)
+        assertTrue(state.pagingState is PagingState.Error)
+        assertEquals(errorMessage, (state.pagingState as PagingState.Error).message)
+    }
+}


### PR DESCRIPTION
Refactored the home screen's state management to use a unified UI State model. This change replaces discrete boolean and string fields with a structured state machine using sealed classes (`LoadState`, `PagingState`). 

Key improvements:
1. **Unified State Source**: `HomeViewModel` now exposes a single `uiState` flow, ensuring the UI always reflects a consistent snapshot of the data.
2. **Clearer UI Transitions**: Explicitly handles initial load vs. pagination. Added `ErrorView` and `EmptyView` for the home screen's first load.
3. **Enhanced Pagination**: `VideoFeed` now triggers data loading when nearing the end of the list and displays a non-blocking loading indicator or retry button if paging fails.
4. **Optimistic Updates**: Maintained optimistic UI for Likes and Follows, ensuring immediate user feedback with automatic reversal on network failure.
5. **Testing**: Added `HomeViewModelTest` covering initial success/failure and pagination success/failure scenarios.

Fixes #39

---
*PR created automatically by Jules for task [5175273266674671937](https://jules.google.com/task/5175273266674671937) started by @zx2121651*