### PR TITLE
Improve home screen first-load failure and retry experience

### DIFF
--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/data/HomeRepository.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/data/HomeRepository.kt
@@ -11,6 +11,16 @@ import javax.inject.Singleton
 class HomeRepository @Inject constructor(
     private val remoteDataSource: HomeDataSource
 ) {
-    suspend fun getInitialVideos(): Resource<List<VideoModel>> = try { Resource.Success(remoteDataSource.getVideos(0)) } catch (e: Exception) { Resource.Error(e.message ?: "Unknown Error", AppError.UnknownError) }
-    suspend fun loadMoreVideos(page: Int): Resource<List<VideoModel>> = try { Resource.Success(remoteDataSource.getVideos(page)) } catch (e: Exception) { Resource.Error(e.message ?: "Unknown Error", AppError.UnknownError) }
+    suspend fun getInitialVideos(): Resource<List<VideoModel>> = safeApiCall { remoteDataSource.getVideos(0) }
+    suspend fun loadMoreVideos(page: Int): Resource<List<VideoModel>> = safeApiCall { remoteDataSource.getVideos(page) }
+
+    private suspend fun <T> safeApiCall(call: suspend () -> T): Resource<T> {
+        return try {
+            Resource.Success(call())
+        } catch (e: java.io.IOException) {
+            Resource.Error("网络连接错误，请检查网络设置", AppError.NetworkError)
+        } catch (e: Exception) {
+            Resource.Error(e.message ?: "服务器响应异常", AppError.ServerError)
+        }
+    }
 }

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/data/source/HomeDataSource.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/data/source/HomeDataSource.kt
@@ -17,33 +17,31 @@ class RemoteHomeDataSource @Inject constructor(
     override suspend fun getVideos(page: Int): List<VideoModel> {
         val requestTime = if (page == 0) null else currentNextTime
 
-        try {
-            val response = apiService.getFeed(latestTime = requestTime)
+        val response = apiService.getFeed(latestTime = requestTime)
 
-            val list = response.videoList
-            if (response.statusCode == 0 && list != null) {
-                currentNextTime = response.nextTime
-                return list.map { dto ->
-                    VideoModel(
-                        id = dto.id,
-                        playUrl = dto.playUrl,
-                        coverUrl = dto.coverUrl,
-                        title = dto.title,
-                    authorId = dto.author.id,
-                        authorName = dto.author.name,
-                        authorAvatar = dto.author.avatar,
-                        likeCount = formatCount(dto.favoriteCount),
-                        commentCount = formatCount(dto.commentCount),
-                        shareCount = "分享", // Placeholder
-                        isLiked = dto.isFavorite,
-                        isFollowed = dto.author.isFollow
-                    )
-                }
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
+        if (response.statusCode != 0) {
+            throw Exception(response.statusMsg ?: "Server Error")
         }
-        return emptyList()
+
+        val list = response.videoList ?: return emptyList()
+
+        currentNextTime = response.nextTime
+        return list.map { dto ->
+            VideoModel(
+                id = dto.id,
+                playUrl = dto.playUrl,
+                coverUrl = dto.coverUrl,
+                title = dto.title,
+                authorId = dto.author.id,
+                authorName = dto.author.name,
+                authorAvatar = dto.author.avatar,
+                likeCount = formatCount(dto.favoriteCount),
+                commentCount = formatCount(dto.commentCount),
+                shareCount = "分享", // Placeholder
+                isLiked = dto.isFavorite,
+                isFollowed = dto.author.isFollow
+            )
+        }
     }
 
     private fun formatCount(count: Long): String {

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/HomeScreen.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/HomeScreen.kt
@@ -3,6 +3,7 @@ package com.app.douyin.pro.feature.home.ui
 
 import androidx.compose.animation.*
 import androidx.compose.animation.core.*
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -66,6 +67,7 @@ fun HomeScreen(
             is LoadState.Error -> {
                 ErrorView(
                     message = loadState.message,
+                    errorCode = loadState.error?.code,
                     onRetry = { viewModel.loadInitialData() }
                 )
             }
@@ -145,7 +147,7 @@ private fun HomeContent(
 }
 
 @Composable
-fun ErrorView(message: String, onRetry: () -> Unit) {
+fun ErrorView(message: String, errorCode: Int? = null, onRetry: () -> Unit) {
     Column(
         modifier = Modifier.fillMaxSize().padding(32.dp),
         verticalArrangement = Arrangement.Center,
@@ -154,21 +156,32 @@ fun ErrorView(message: String, onRetry: () -> Unit) {
         Icon(
             Icons.Filled.Warning,
             contentDescription = null,
-            tint = Color.Gray,
+            tint = Color(0xFFFF2C55),
             modifier = Modifier.size(64.dp)
         )
         Spacer(modifier = Modifier.height(16.dp))
         Text(
-            text = "加载失败: $message",
+            text = "加载失败",
             color = Color.White,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center
         )
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = if (errorCode != null) "$message ($errorCode)" else message,
+            color = Color.Gray,
+            fontSize = 14.sp,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(32.dp))
         Button(
             onClick = onRetry,
+            modifier = Modifier.width(140.dp).height(48.dp),
+            shape = RoundedCornerShape(24.dp),
             colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF2C55))
         ) {
-            Text("重试")
+            Text("点击重试", fontWeight = FontWeight.Bold)
         }
     }
 }
@@ -181,7 +194,7 @@ fun EmptyView(onRetry: () -> Unit) {
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Icon(
-            Icons.Filled.Info,
+            Icons.Filled.Inbox,
             contentDescription = null,
             tint = Color.Gray,
             modifier = Modifier.size(64.dp)
@@ -190,14 +203,17 @@ fun EmptyView(onRetry: () -> Unit) {
         Text(
             text = "暂无视频内容",
             color = Color.White,
+            fontSize = 18.sp,
             textAlign = TextAlign.Center
         )
         Spacer(modifier = Modifier.height(24.dp))
-        Button(
+        OutlinedButton(
             onClick = onRetry,
-            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF2C55))
+            modifier = Modifier.width(120.dp),
+            border = BorderStroke(1.dp, Color.Gray),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.White)
         ) {
-            Text("刷新")
+            Text("重试")
         }
     }
 }

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/HomeViewModel.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/HomeViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.app.douyin.pro.feature.home.domain.model.VideoModel
 import com.app.douyin.pro.feature.home.domain.usecase.GetVideosUseCase
 import com.app.douyin.pro.feature.home.domain.usecase.LoadMoreVideosUseCase
+import com.app.douyin.pro.lib.media.model.AppError
 import com.app.douyin.pro.lib.media.model.Resource
 import com.app.douyin.pro.lib.media.network.DouyinApiService
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,7 +20,7 @@ sealed class LoadState {
     object Idle : LoadState()
     object Loading : LoadState()
     data class Success(val isEmpty: Boolean) : LoadState()
-    data class Error(val message: String) : LoadState()
+    data class Error(val message: String, val error: AppError? = null) : LoadState()
 }
 
 sealed class PagingState {
@@ -51,6 +52,8 @@ class HomeViewModel @Inject constructor(
     }
 
     fun loadInitialData() {
+        if (_uiState.value.loadState is LoadState.Loading) return
+
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(loadState = LoadState.Loading)
             when (val result = getVideosUseCase()) {
@@ -63,7 +66,7 @@ class HomeViewModel @Inject constructor(
                 }
                 is Resource.Error -> {
                     _uiState.value = _uiState.value.copy(
-                        loadState = LoadState.Error(result.message)
+                        loadState = LoadState.Error(result.message, result.error)
                     )
                 }
                 else -> {


### PR DESCRIPTION
This PR improves the DouyinLite home screen's first-load experience by providing clear feedback and a robust retry path when loading fails.

Key changes:
1.  **Data Layer Transparency**: `RemoteHomeDataSource` now throws exceptions on non-zero API status codes or network failures, allowing the UI to distinguish between "no content" and "load failed".
2.  **Robust Repository**: `HomeRepository` uses a `safeApiCall` helper to wrap API calls, providing consistent mapping of exceptions to `AppError` types.
3.  **Safe ViewModel**: `HomeViewModel` now includes a loading guard to prevent request storms and propagates detailed error information to the UI.
4.  **Distinct UI States**:
    -   `ErrorView` now features a "Warning" icon (red tint), a bold "Load Failed" title, detailed error messages with optional error codes, and a prominent "Click to Retry" button.
    -   `EmptyView` uses an "Inbox" icon and an outlined "Retry" button, clearly separating it from the failure state.

These changes ensure a stable recovery path for users and prevent loss of engagement due to unclear error states.

Fixes #40

---
*PR created automatically by Jules for task [8060164788382671150](https://jules.google.com/task/8060164788382671150) started by @zx2121651*