### PR TITLE
Unified Video Playback State Machine

### DIFF
--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/components/VideoPlayerComponent.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/components/VideoPlayerComponent.kt
@@ -18,14 +18,15 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.media3.common.Player
 import androidx.media3.ui.PlayerView
 import coil.compose.AsyncImage
 import com.app.douyin.pro.lib.media.VideoPlayerManager
+import com.app.douyin.pro.lib.media.state.VideoPlayerState
 
 @Composable
 fun VideoPlayerComponent(
@@ -38,18 +39,10 @@ fun VideoPlayerComponent(
     val context = LocalContext.current
     val playerManager = remember { VideoPlayerManager.getInstance(context) }
     val player = remember(url) { playerManager.getPlayer(url) }
-
-    var isFirstFrameRendered by remember { mutableStateOf(false) }
+    val playerState by playerManager.getState(url).collectAsState()
 
     DisposableEffect(player) {
-        val listener = object : Player.Listener {
-            override fun onRenderedFirstFrame() {
-                isFirstFrameRendered = true
-            }
-        }
-        player.addListener(listener)
         onDispose {
-            player.removeListener(listener)
             playerManager.releasePlayer(url)
         }
     }
@@ -77,8 +70,13 @@ fun VideoPlayerComponent(
             modifier = Modifier.fillMaxSize()
         )
 
+        val showCover = when (playerState) {
+            is VideoPlayerState.Idle, is VideoPlayerState.Preparing -> true
+            is VideoPlayerState.Buffering, is VideoPlayerState.Playing, is VideoPlayerState.Paused, is VideoPlayerState.Ready, is VideoPlayerState.Ended, is VideoPlayerState.Error -> false
+        }
+
         AnimatedVisibility(
-            visible = !isFirstFrameRendered,
+            visible = showCover,
             exit = fadeOut(animationSpec = tween(durationMillis = 300)),
             modifier = Modifier.fillMaxSize()
         ) {
@@ -105,6 +103,15 @@ fun VideoPlayerComponent(
                 contentDescription = "Paused",
                 tint = Color.White.copy(alpha = 0.5f),
                 modifier = Modifier.size(80.dp)
+            )
+        }
+
+        if (playerState is VideoPlayerState.Buffering || playerState is VideoPlayerState.Preparing) {
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .size(40.dp)
+                    .align(Alignment.Center),
+                color = Color.White.copy(alpha = 0.5f)
             )
         }
     }

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/VideoPlayerManager.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/VideoPlayerManager.kt
@@ -10,14 +10,22 @@ import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.MediaSource
+import android.util.Log
+import androidx.media3.common.PlaybackException
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import com.app.douyin.pro.lib.media.state.VideoPlayerState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.io.IOException
 
 @OptIn(UnstableApi::class)
 class VideoPlayerManager private constructor(private val context: Context) {
+
+    private val TAG = "VideoPlayerManager"
 
     companion object {
         @Volatile
@@ -33,6 +41,8 @@ class VideoPlayerManager private constructor(private val context: Context) {
     private val playerPoolSize = 3
     private val idlePlayers = mutableListOf<ExoPlayer>()
     private val activePlayers = mutableMapOf<String, ExoPlayer>()
+    private val playerStates = mutableMapOf<String, MutableStateFlow<VideoPlayerState>>()
+    private val playerListeners = mutableMapOf<String, Player.Listener>()
     private val preLoadScope = CoroutineScope(Dispatchers.IO)
 
     init {
@@ -51,9 +61,7 @@ class VideoPlayerManager private constructor(private val context: Context) {
 
     fun getPlayer(url: String): ExoPlayer {
         // If already active, return it
-        if (activePlayers.containsKey(url)) {
-            return activePlayers[url]!!
-        }
+        activePlayers[url]?.let { return it }
 
         // Get from idle pool or create new if empty
         val player = if (idlePlayers.isNotEmpty()) {
@@ -65,6 +73,9 @@ class VideoPlayerManager private constructor(private val context: Context) {
                 val recycledPlayer = activePlayers.remove(oldestUrl)!!
                 recycledPlayer.stop()
                 recycledPlayer.clearMediaItems()
+                // Clean up state and listener for the recycled player
+                playerStates.remove(oldestUrl)
+                playerListeners.remove(oldestUrl)?.let { recycledPlayer.removeListener(it) }
                 recycledPlayer
             } else {
                 createPlayer() // Fallback
@@ -72,8 +83,46 @@ class VideoPlayerManager private constructor(private val context: Context) {
         }
 
         activePlayers[url] = player
+        val stateFlow = MutableStateFlow<VideoPlayerState>(VideoPlayerState.Idle)
+        playerStates[url] = stateFlow
+
+        val listener = object : Player.Listener {
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                val newState = when (playbackState) {
+                    Player.STATE_IDLE -> VideoPlayerState.Idle
+                    Player.STATE_BUFFERING -> VideoPlayerState.Buffering
+                    Player.STATE_READY -> {
+                        if (player.playWhenReady) VideoPlayerState.Playing else VideoPlayerState.Paused
+                    }
+                    Player.STATE_ENDED -> VideoPlayerState.Ended
+                    else -> VideoPlayerState.Idle
+                }
+                updateState(url, newState)
+            }
+
+            override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
+                if (player.playbackState == Player.STATE_READY) {
+                    val newState = if (playWhenReady) VideoPlayerState.Playing else VideoPlayerState.Paused
+                    updateState(url, newState)
+                }
+            }
+
+            override fun onPlayerError(error: PlaybackException) {
+                updateState(url, VideoPlayerState.Error(error.message, error.errorCode))
+            }
+
+            override fun onIsLoadingChanged(isLoading: Boolean) {
+                if (isLoading && player.playbackState == Player.STATE_BUFFERING) {
+                    updateState(url, VideoPlayerState.Buffering)
+                }
+            }
+        }
+
+        player.addListener(listener)
+        playerListeners[url] = listener
 
         // Prepare media
+        updateState(url, VideoPlayerState.Preparing)
         val mediaSource = createMediaSource(url)
         player.setMediaSource(mediaSource)
         player.prepare()
@@ -81,11 +130,27 @@ class VideoPlayerManager private constructor(private val context: Context) {
         return player
     }
 
+    private fun updateState(url: String, newState: VideoPlayerState) {
+        val stateFlow = playerStates[url]
+        if (stateFlow != null && stateFlow.value != newState) {
+            Log.d(TAG, "Video [$url] state transition: ${stateFlow.value} -> $newState")
+            stateFlow.value = newState
+        }
+    }
+
+    fun getState(url: String): StateFlow<VideoPlayerState> {
+        return playerStates[url]?.asStateFlow() ?: MutableStateFlow(VideoPlayerState.Idle).asStateFlow()
+    }
+
     fun releasePlayer(url: String) {
         val player = activePlayers.remove(url)
         if (player != null) {
             player.stop()
             player.clearMediaItems()
+
+            playerListeners.remove(url)?.let { player.removeListener(it) }
+            playerStates.remove(url)
+
             if (idlePlayers.size < playerPoolSize) {
                 idlePlayers.add(player)
             } else {

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/state/VideoPlayerState.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/state/VideoPlayerState.kt
@@ -1,0 +1,25 @@
+package com.app.douyin.pro.lib.media.state
+
+sealed class VideoPlayerState {
+    object Idle : VideoPlayerState()
+    object Preparing : VideoPlayerState()
+    object Ready : VideoPlayerState()
+    object Playing : VideoPlayerState()
+    object Paused : VideoPlayerState()
+    object Buffering : VideoPlayerState()
+    object Ended : VideoPlayerState()
+    data class Error(val message: String?, val errorCode: Int? = null) : VideoPlayerState()
+
+    override fun toString(): String {
+        return when (this) {
+            is Idle -> "Idle"
+            is Preparing -> "Preparing"
+            is Ready -> "Ready"
+            is Playing -> "Playing"
+            is Paused -> "Paused"
+            is Buffering -> "Buffering"
+            is Ended -> "Ended"
+            is Error -> "Error(message=$message, errorCode=$errorCode)"
+        }
+    }
+}


### PR DESCRIPTION
Established a unified video playback state machine to manage the complex lifecycle of video playback. This change centralizes playback state management in VideoPlayerManager, providing a reliable source of truth for the UI and other layers. The VideoPlayerComponent has been refactored to observe these states reactively, decoupling it from the underlying Media3 player implementation details.

Fixes #47

---
*PR created automatically by Jules for task [18320976349427032645](https://jules.google.com/task/18320976349427032645) started by @zx2121651*