### PR TITLE
Optimize video preload strategy with configurable models

### DIFF
--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/FriendsScreen.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/FriendsScreen.kt
@@ -90,17 +90,17 @@ fun FriendsScreen() {
 
     // Observe pager changes for preloading
     val context = LocalContext.current
-    LaunchedEffect(pagerState) {
+    LaunchedEffect(pagerState, videos) {
         snapshotFlow { pagerState.currentPage }.collect { page ->
              val playerManager = VideoPlayerManager.getInstance(context)
-             // Preload next video
-             if (page > 0 && page < videos.size) { // Because page 0 is discover section, video indices are page - 1
-                 playerManager.preLoad(videos[page]) // Current page is `page`, so next video is at index `page`
+
+             // page 0 is discover section, video indices are page - 1
+             val preloadUrls = if (page < videos.size) {
+                 videos.subList(page, (page + 3).coerceAtMost(videos.size))
+             } else {
+                 emptyList()
              }
-             // Preload previous video
-             if (page > 1) {
-                 playerManager.preLoad(videos[page - 2]) // Current page is `page`, so previous video is at index `page - 2`
-             }
+             playerManager.updatePreloadList(preloadUrls)
         }
     }
 

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/components/VideoFeed.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/components/VideoFeed.kt
@@ -40,11 +40,15 @@ fun VideoFeed(
     val context = LocalContext.current
     val playerManager = remember { VideoPlayerManager.getInstance(context) }
 
-    // Preload next 1 video to balance Zero First-Frame Delay and network bandwidth
-    LaunchedEffect(pagerState.currentPage) {
-        val nextIndex = pagerState.currentPage + 1
-        if (nextIndex < videos.size) {
-            playerManager.preLoad(videos[nextIndex].playUrl)
+    // Preload strategy: update the preload list based on current page
+    LaunchedEffect(pagerState.currentPage, videos) {
+        if (videos.isNotEmpty()) {
+            val preloadUrls = videos.subList(
+                (pagerState.currentPage + 1).coerceAtMost(videos.size),
+                (pagerState.currentPage + 5).coerceAtMost(videos.size)
+            ).map { it.playUrl }
+
+            playerManager.updatePreloadList(preloadUrls)
         }
 
         // Trigger load more when reaching near the end

--- a/DouyinLite/lib_media/src/main/AndroidManifest.xml
+++ b/DouyinLite/lib_media/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/VideoPlayerManager.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/VideoPlayerManager.kt
@@ -14,13 +14,15 @@ import android.util.Log
 import androidx.media3.common.PlaybackException
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import com.app.douyin.pro.lib.media.state.VideoPlayerState
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import com.app.douyin.pro.lib.media.strategy.NetworkQuality
+import com.app.douyin.pro.lib.media.strategy.PreloadStrategy
+import com.app.douyin.pro.lib.media.util.NetworkMonitor
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
 
 @OptIn(UnstableApi::class)
 class VideoPlayerManager private constructor(private val context: Context) {
@@ -43,12 +45,22 @@ class VideoPlayerManager private constructor(private val context: Context) {
     private val activePlayers = mutableMapOf<String, ExoPlayer>()
     private val playerStates = mutableMapOf<String, MutableStateFlow<VideoPlayerState>>()
     private val playerListeners = mutableMapOf<String, Player.Listener>()
-    private val preLoadScope = CoroutineScope(Dispatchers.IO)
+    private val preLoadScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val preloadTasks = ConcurrentHashMap<String, Job>()
+    private val preloadStrategy = PreloadStrategy()
+    private val networkMonitor = NetworkMonitor(context)
 
     init {
         // Initialize pool
         for (i in 0 until playerPoolSize) {
             idlePlayers.add(createPlayer())
+        }
+
+        // Observe network quality
+        preLoadScope.launch {
+            networkMonitor.networkQuality.collect { quality ->
+                updateNetworkQuality(quality)
+            }
         }
     }
 
@@ -159,36 +171,67 @@ class VideoPlayerManager private constructor(private val context: Context) {
         }
     }
 
-    fun preLoad(url: String) {
-        // Execute preload in a background coroutine
-        preLoadScope.launch {
+    fun updateNetworkQuality(quality: NetworkQuality) {
+        preloadStrategy.updateNetworkQuality(quality)
+    }
+
+    fun updatePreloadList(urls: List<String>) {
+        val config = preloadStrategy.getConfig()
+        val targetPreloadUrls = urls.take(config.preloadDepth)
+
+        // Cancel tasks that are no longer in the preload list
+        val iterator = preloadTasks.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (!targetPreloadUrls.contains(entry.key) && !activePlayers.containsKey(entry.key)) {
+                Log.d(TAG, "Cancelling preload for: ${entry.key}")
+                entry.value.cancel()
+                iterator.remove()
+            }
+        }
+
+        // Start new preload tasks
+        targetPreloadUrls.forEach { url ->
+            if (!preloadTasks.containsKey(url) && !activePlayers.containsKey(url)) {
+                preLoad(url, config.bufferSize)
+            }
+        }
+    }
+
+    private fun preLoad(url: String, bufferSize: Long) {
+        if (bufferSize <= 0) return
+
+        val job = preLoadScope.launch {
             var cacheDataSource: androidx.media3.datasource.DataSource? = null
             try {
+                Log.d(TAG, "Starting preload for: $url with size: $bufferSize")
                 val dataSpec = DataSpec.Builder().setUri(url).build()
                 cacheDataSource = VideoCacheManager.getInstance(context).getCacheDataSourceFactory().createDataSource()
-                // Download the first 1MB of the video
-                val buffer = ByteArray(1024 * 1024)
-                var bytesRead = 0
-                val lengthToRead = buffer.size
+
+                val buffer = ByteArray(64 * 1024) // 64KB chunks
+                var totalBytesRead = 0L
 
                 cacheDataSource.open(dataSpec)
-                while (bytesRead < lengthToRead) {
-                    val read = cacheDataSource.read(buffer, bytesRead, lengthToRead - bytesRead)
+                while (totalBytesRead < bufferSize && isActive) {
+                    val read = cacheDataSource.read(buffer, 0, buffer.size)
                     if (read == -1) break
-                    bytesRead += read
+                    totalBytesRead += read
                 }
-
+                Log.d(TAG, "Completed preload for: $url, read: $totalBytesRead bytes")
+            } catch (e: CancellationException) {
+                Log.d(TAG, "Preload cancelled for: $url")
             } catch (e: IOException) {
-                e.printStackTrace()
+                Log.e(TAG, "Preload failed for: $url", e)
             } finally {
                 try {
                     cacheDataSource?.close()
                 } catch (e: Exception) {
-                    e.printStackTrace()
+                    // Ignore
                 }
+                preloadTasks.remove(url)
             }
-
         }
+        preloadTasks[url] = job
     }
 
     private fun createMediaSource(url: String): MediaSource {

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/strategy/NetworkQuality.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/strategy/NetworkQuality.kt
@@ -1,0 +1,8 @@
+package com.app.douyin.pro.lib.media.strategy
+
+enum class NetworkQuality {
+    WIFI,
+    GOOD,
+    WEAK,
+    NO_NETWORK
+}

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/strategy/PreloadConfig.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/strategy/PreloadConfig.kt
@@ -1,0 +1,33 @@
+package com.app.douyin.pro.lib.media.strategy
+
+data class PreloadConfig(
+    val preloadDepth: Int,
+    val bufferSize: Long,
+    val maxConcurrentTasks: Int = 3
+) {
+    companion object {
+        val WIFI_CONFIG = PreloadConfig(
+            preloadDepth = 3,
+            bufferSize = 1024 * 1024 * 2, // 2MB
+            maxConcurrentTasks = 3
+        )
+
+        val GOOD_CONFIG = PreloadConfig(
+            preloadDepth = 2,
+            bufferSize = 1024 * 1024 * 1, // 1MB
+            maxConcurrentTasks = 2
+        )
+
+        val WEAK_CONFIG = PreloadConfig(
+            preloadDepth = 1,
+            bufferSize = 512 * 1024, // 512KB
+            maxConcurrentTasks = 1
+        )
+
+        val NONE_CONFIG = PreloadConfig(
+            preloadDepth = 0,
+            bufferSize = 0,
+            maxConcurrentTasks = 0
+        )
+    }
+}

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/strategy/PreloadStrategy.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/strategy/PreloadStrategy.kt
@@ -1,0 +1,20 @@
+package com.app.douyin.pro.lib.media.strategy
+
+class PreloadStrategy {
+    private var currentQuality: NetworkQuality = NetworkQuality.WIFI
+
+    fun updateNetworkQuality(quality: NetworkQuality) {
+        if (currentQuality != quality) {
+            currentQuality = quality
+        }
+    }
+
+    fun getConfig(): PreloadConfig {
+        return when (currentQuality) {
+            NetworkQuality.WIFI -> PreloadConfig.WIFI_CONFIG
+            NetworkQuality.GOOD -> PreloadConfig.GOOD_CONFIG
+            NetworkQuality.WEAK -> PreloadConfig.WEAK_CONFIG
+            NetworkQuality.NO_NETWORK -> PreloadConfig.NONE_CONFIG
+        }
+    }
+}

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/util/NetworkMonitor.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/util/NetworkMonitor.kt
@@ -1,0 +1,62 @@
+package com.app.douyin.pro.lib.media.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import com.app.douyin.pro.lib.media.strategy.NetworkQuality
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class NetworkMonitor(context: Context) {
+    private val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    private val _networkQuality = MutableStateFlow(getCurrentQuality())
+    val networkQuality: StateFlow<NetworkQuality> = _networkQuality.asStateFlow()
+
+    private val networkCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            updateQuality()
+        }
+
+        override fun onLost(network: Network) {
+            updateQuality()
+        }
+
+        override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
+            updateQuality()
+        }
+    }
+
+    init {
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+        connectivityManager.registerNetworkCallback(request, networkCallback)
+    }
+
+    private fun updateQuality() {
+        _networkQuality.value = getCurrentQuality()
+    }
+
+    private fun getCurrentQuality(): NetworkQuality {
+        val activeNetwork = connectivityManager.activeNetwork ?: return NetworkQuality.NO_NETWORK
+        val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork) ?: return NetworkQuality.NO_NETWORK
+
+        return when {
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> NetworkQuality.WIFI
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> {
+                // Simplification: assume GOOD for now, could check link speed
+                NetworkQuality.GOOD
+            }
+            else -> NetworkQuality.GOOD
+        }
+    }
+
+    fun unregister() {
+        connectivityManager.unregisterNetworkCallback(networkCallback)
+    }
+}

--- a/DouyinLite/lib_media/src/test/java/com/app/douyin/pro/lib/media/strategy/PreloadStrategyTest.kt
+++ b/DouyinLite/lib_media/src/test/java/com/app/douyin/pro/lib/media/strategy/PreloadStrategyTest.kt
@@ -1,0 +1,34 @@
+package com.app.douyin.pro.lib.media.strategy
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PreloadStrategyTest {
+
+    @Test
+    fun testWifiConfig() {
+        val strategy = PreloadStrategy()
+        strategy.updateNetworkQuality(NetworkQuality.WIFI)
+        val config = strategy.getConfig()
+        assertEquals(3, config.preloadDepth)
+        assertEquals(1024 * 1024 * 2L, config.bufferSize)
+    }
+
+    @Test
+    fun testWeakConfig() {
+        val strategy = PreloadStrategy()
+        strategy.updateNetworkQuality(NetworkQuality.WEAK)
+        val config = strategy.getConfig()
+        assertEquals(1, config.preloadDepth)
+        assertEquals(512 * 1024L, config.bufferSize)
+    }
+
+    @Test
+    fun testNoNetworkConfig() {
+        val strategy = PreloadStrategy()
+        strategy.updateNetworkQuality(NetworkQuality.NO_NETWORK)
+        val config = strategy.getConfig()
+        assertEquals(0, config.preloadDepth)
+        assertEquals(0L, config.bufferSize)
+    }
+}


### PR DESCRIPTION
Optimized the video preloading strategy by making it configurable and network-aware. Key changes include:
- A new `PreloadStrategy` that adapts to network quality.
- `VideoPlayerManager` now supports updating a list of target URLs for preloading, automatically cancelling tasks for videos that are no longer needed.
- Integrated the new strategy into `VideoFeed` and `FriendsScreen`.
- Added a `NetworkMonitor` to provide real-time network status to the preloading system.

Fixes #48

---
*PR created automatically by Jules for task [15440214084348267334](https://jules.google.com/task/15440214084348267334) started by @zx2121651*