### PR TITLE
Establish Stable Video Caching and Prevent Duplicate Downloads

### DIFF
--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/VideoCacheManager.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/VideoCacheManager.kt
@@ -7,7 +7,9 @@ import androidx.media3.database.StandaloneDatabaseProvider
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
+import android.util.Log
 import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.datasource.cache.CacheKeyFactory
 import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
 import androidx.media3.datasource.cache.SimpleCache
 import java.io.File
@@ -43,10 +45,28 @@ class VideoCacheManager private constructor(context: Context) {
 
         val defaultDataSourceFactory = DefaultDataSource.Factory(context, httpDataSourceFactory)
 
+        val cacheKeyFactory = CacheKeyFactory { dataSpec ->
+            dataSpec.key ?: dataSpec.uri.buildUpon().clearQuery().build().toString()
+        }
+
+        val eventListener = object : CacheDataSource.EventListener {
+            override fun onCachedBytesRead(cacheSize: Long, cachedBytesRead: Long) {
+                if (cachedBytesRead > 0) {
+                    Log.v("VideoCache", "Cache Hit: read $cachedBytesRead bytes from cache.")
+                }
+            }
+
+            override fun onCacheIgnored(reason: Int) {
+                Log.w("VideoCache", "Cache Ignored: reason=$reason")
+            }
+        }
+
         cacheDataSourceFactory = CacheDataSource.Factory()
             .setCache(cache)
             .setUpstreamDataSourceFactory(defaultDataSourceFactory)
-            // 边播边存
+            .setCacheKeyFactory(cacheKeyFactory)
+            .setEventListener(eventListener)
+            // 边播边存，且缓存出错时不影响正常播放
             .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
     }
 

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/VideoPlayerManager.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/VideoPlayerManager.kt
@@ -135,6 +135,7 @@ class VideoPlayerManager private constructor(private val context: Context) {
 
         // Prepare media
         updateState(url, VideoPlayerState.Preparing)
+        Log.d(TAG, "Preparing player for: $url (potential cache use enabled)")
         val mediaSource = createMediaSource(url)
         player.setMediaSource(mediaSource)
         player.prepare()
@@ -201,19 +202,31 @@ class VideoPlayerManager private constructor(private val context: Context) {
     private fun preLoad(url: String, bufferSize: Long) {
         if (bufferSize <= 0) return
 
+        // Concurrent request de-duplication is already partially handled by the caller (updatePreloadList),
+        // but we double check here to ensure we don't start duplicate jobs.
+        if (preloadTasks.containsKey(url)) return
+
         val job = preLoadScope.launch {
             var cacheDataSource: androidx.media3.datasource.DataSource? = null
             try {
                 Log.d(TAG, "Starting preload for: $url with size: $bufferSize")
-                val dataSpec = DataSpec.Builder().setUri(url).build()
-                cacheDataSource = VideoCacheManager.getInstance(context).getCacheDataSourceFactory().createDataSource()
+                // Use the same CacheDataSourceFactory to ensure stable cache key logic is applied
+                val dataSourceFactory = VideoCacheManager.getInstance(context).getCacheDataSourceFactory()
+                cacheDataSource = dataSourceFactory.createDataSource()
+
+                val dataSpec = DataSpec.Builder()
+                    .setUri(url)
+                    .setLength(bufferSize)
+                    .build()
 
                 val buffer = ByteArray(64 * 1024) // 64KB chunks
                 var totalBytesRead = 0L
 
                 cacheDataSource.open(dataSpec)
                 while (totalBytesRead < bufferSize && isActive) {
-                    val read = cacheDataSource.read(buffer, 0, buffer.size)
+                    val remaining = bufferSize - totalBytesRead
+                    val toRead = if (remaining < buffer.size) remaining.toInt() else buffer.size
+                    val read = cacheDataSource.read(buffer, 0, toRead)
                     if (read == -1) break
                     totalBytesRead += read
                 }
@@ -221,7 +234,7 @@ class VideoPlayerManager private constructor(private val context: Context) {
             } catch (e: CancellationException) {
                 Log.d(TAG, "Preload cancelled for: $url")
             } catch (e: IOException) {
-                Log.e(TAG, "Preload failed for: $url", e)
+                Log.e(TAG, "Preload failed for: $url (will retry on playback if needed)", e)
             } finally {
                 try {
                     cacheDataSource?.close()


### PR DESCRIPTION
This PR fixes several issues with the video caching mechanism to ensure high cache hit rates and prevent redundant network requests.

Key changes:
1. **Stable Cache Keys**: Introduced `CacheKeyFactory` in `VideoCacheManager` that normalizes URIs by stripping query parameters. This ensures that videos with dynamic CDN tokens are correctly identified as the same resource in the cache.
2. **Cache Observability**: Added an `EventListener` to the `CacheDataSource` to provide visibility into cache hits and misses via logs, aiding in performance auditing.
3. **Preload De-duplication**: Updated `VideoPlayerManager` to prevent starting multiple concurrent preload jobs for the same URL.
4. **Configuration Consistency**: Guaranteed that both preloading and playback use the exact same `CacheDataSource` configuration, enabling playback to immediately benefit from preloaded data.
5. **Robustness**: Maintained `FLAG_IGNORE_CACHE_ON_ERROR` to ensure video playback remains functional even if cache errors occur.

These changes collectively stabilize the cache behavior, reduce bandwidth costs, and improve the user experience by increasing the likelihood of instant video playback from local storage.

Fixes #49

---
*PR created automatically by Jules for task [10128912442444630208](https://jules.google.com/task/10128912442444630208) started by @zx2121651*