### PR TITLE
Fix Interaction State and Count Inconsistency

### DIFF
--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/data/SearchRepository.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/data/SearchRepository.kt
@@ -24,9 +24,9 @@ class SearchRepository @Inject constructor(
                             authorId = dto.author.id,
                             authorName = dto.author.name,
                             authorAvatar = dto.author.avatar,
-                            likeCount = dto.favoriteCount.toString(),
-                            commentCount = dto.commentCount.toString(),
-                            shareCount = "0", // 暂无 shareCount 字段
+                            likeCount = dto.favoriteCount,
+                            commentCount = dto.commentCount,
+                            shareCount = 0L, // 暂无 shareCount 字段
                             isLiked = dto.isFavorite,
                             isFollowed = dto.author.isFollow
                         )

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/data/source/HomeDataSource.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/data/source/HomeDataSource.kt
@@ -31,22 +31,14 @@ class RemoteHomeDataSource @Inject constructor(
                 authorId = dto.author.id,
                 authorName = dto.author.name,
                 authorAvatar = dto.author.avatar,
-                likeCount = formatCount(dto.favoriteCount),
-                commentCount = formatCount(dto.commentCount),
-                shareCount = "分享", // Placeholder
+                likeCount = dto.favoriteCount,
+                commentCount = dto.commentCount,
+                shareCount = 0L, // Placeholder
                 isLiked = dto.isFavorite,
                 isFollowed = dto.author.isFollow
             )
         }
         return VideoPage(videos, response.nextTime)
-    }
-
-    private fun formatCount(count: Long): String {
-        return if (count >= 10000) {
-            String.format("%.1fw", count / 10000.0)
-        } else {
-            count.toString()
-        }
     }
 }
 
@@ -68,9 +60,9 @@ class MockHomeDataSource : HomeDataSource {
                 authorId = 1,
                 authorName = "Mock User",
                 authorAvatar = null,
-                likeCount = "1.2w",
-                commentCount = "856",
-                shareCount = "分享",
+                likeCount = 12000L,
+                commentCount = 856L,
+                shareCount = 0L,
                 isLiked = false,
                 isFollowed = false
             )

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/domain/model/VideoModel.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/domain/model/VideoModel.kt
@@ -8,9 +8,9 @@ data class VideoModel(
     val authorId: Long,
     val authorName: String,
     val authorAvatar: String?,
-    val likeCount: String,
-    val commentCount: String,
-    val shareCount: String,
+    val likeCount: Long,
+    val commentCount: Long,
+    val shareCount: Long,
     val isLiked: Boolean,
     val isFollowed: Boolean
 )

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/FriendsScreen.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/FriendsScreen.kt
@@ -124,9 +124,9 @@ fun FriendsScreen() {
                         authorId = 2,
                         authorName = "你的好友",
                         authorAvatar = null,
-                        likeCount = "88",
-                        commentCount = "12",
-                        shareCount = "分享",
+                        likeCount = 88L,
+                        commentCount = 12L,
+                        shareCount = 0L,
                         isLiked = false,
                         isFollowed = true
                     ),

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/HomeScreen.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/HomeScreen.kt
@@ -262,7 +262,18 @@ fun VideoPage(video: VideoModel, isVisible: Boolean) {
             musicTitle = "原声 - 潮流音乐库"
         )
 
-        if (showCommentsSheet) CommentsBottomSheet(videoId = video.id, commentCount = video.commentCount, onDismiss = { showCommentsSheet = false })
+        if (showCommentsSheet) {
+            val commentViewModel: com.app.douyin.pro.feature.home.viewmodel.CommentViewModel = hiltViewModel()
+            LaunchedEffect(video.id) {
+                commentViewModel.loadComments(video.id, video.commentCount)
+            }
+            CommentsBottomSheet(
+                videoId = video.id,
+                commentCount = video.commentCount,
+                onDismiss = { showCommentsSheet = false },
+                viewModel = commentViewModel
+            )
+        }
         if (showShareSheet) ShareBottomSheet(onDismiss = { showShareSheet = false })
         if (showLongPressMenu) LongPressMenu(onDismiss = { showLongPressMenu = false })
     }

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/SearchScreen.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/SearchScreen.kt
@@ -258,7 +258,7 @@ fun SearchResultItem(video: VideoModel) {
                 )
                 Spacer(modifier = Modifier.width(4.dp))
                 Text(
-                    text = video.likeCount,
+                    text = com.app.douyin.pro.lib.media.util.CountFormatter.format(video.likeCount),
                     color = Color.Gray,
                     fontSize = 12.sp
                 )

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/components/ActionPanel.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/components/ActionPanel.kt
@@ -26,13 +26,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberAsyncImagePainter
+import com.app.douyin.pro.lib.media.util.CountFormatter
 
 @Composable
 fun ActionPanel(
     isLiked: Boolean,
-    likeCount: String,
-    commentCount: String,
-    shareCount: String,
+    likeCount: Long,
+    commentCount: Long,
+    shareCount: Long,
     avatarUrl: String?,
     isFollowed: Boolean,
     onLikeClick: () -> Unit,
@@ -79,20 +80,20 @@ fun ActionPanel(
 
         ActionItem(
             icon = Icons.Filled.Favorite,
-            count = likeCount,
+            count = CountFormatter.format(likeCount),
             tint = if (isLiked) Color(0xFFFF2C55) else Color.White,
             onClick = onLikeClick
         )
 
         ActionItem(
             icon = Icons.Filled.Message,
-            count = commentCount,
+            count = CountFormatter.format(commentCount),
             onClick = onCommentClick
         )
 
         ActionItem(
             icon = Icons.Filled.Share,
-            count = shareCount,
+            count = CountFormatter.format(shareCount),
             onClick = onShareClick
         )
 

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/components/CommentsBottomSheet.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/components/CommentsBottomSheet.kt
@@ -31,12 +31,13 @@ import com.app.douyin.pro.feature.home.domain.model.CommentModel
 import com.app.douyin.pro.feature.home.domain.model.CommentStatus
 import com.app.douyin.pro.feature.home.viewmodel.CommentUiState
 import com.app.douyin.pro.feature.home.viewmodel.CommentViewModel
+import com.app.douyin.pro.lib.media.util.CountFormatter
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CommentsBottomSheet(
     videoId: Long,
-    commentCount: String,
+    commentCount: Long,
     onDismiss: () -> Unit,
     viewModel: CommentViewModel = hiltViewModel()
 ) {
@@ -46,10 +47,6 @@ fun CommentsBottomSheet(
 
     var inputText by remember { mutableStateOf("") }
     var replyToComment by remember { mutableStateOf<CommentModel?>(null) }
-
-    LaunchedEffect(videoId) {
-        viewModel.loadComments(videoId)
-    }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -68,7 +65,7 @@ fun CommentsBottomSheet(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Spacer(modifier = Modifier.width(24.dp))
-                    Text("全部评论 ($commentCount)", color = Color.White, fontWeight = FontWeight.Bold, fontSize = 16.sp)
+                    Text("全部评论 (${CountFormatter.format(commentCount)})", color = Color.White, fontWeight = FontWeight.Bold, fontSize = 16.sp)
                     IconButton(onClick = onDismiss, modifier = Modifier.size(24.dp)) {
                         Icon(Icons.Filled.Close, contentDescription = "Close", tint = Color.Gray)
                     }

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/CommentViewModel.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/CommentViewModel.kt
@@ -8,6 +8,7 @@ import com.app.douyin.pro.feature.home.domain.usecase.GetCommentsUseCase
 import com.app.douyin.pro.feature.home.domain.usecase.PostCommentUseCase
 import com.app.douyin.pro.lib.media.model.Resource
 import com.app.douyin.pro.lib.media.auth.AuthManager
+import com.app.douyin.pro.lib.media.interaction.VideoInteractionManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -26,7 +27,8 @@ sealed class CommentUiState {
 class CommentViewModel @Inject constructor(
     private val getCommentsUseCase: GetCommentsUseCase,
     private val postCommentUseCase: PostCommentUseCase,
-    private val authManager: AuthManager
+    private val authManager: AuthManager,
+    private val interactionManager: VideoInteractionManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<CommentUiState>(CommentUiState.Loading)
@@ -36,9 +38,11 @@ class CommentViewModel @Inject constructor(
     val comments: StateFlow<List<CommentModel>> = _comments.asStateFlow()
 
     private var currentVideoId: Long = -1L
+    private var currentCommentCount: Long = 0L
 
-    fun loadComments(videoId: Long) {
+    fun loadComments(videoId: Long, commentCount: Long = 0L) {
         currentVideoId = videoId
+        currentCommentCount = commentCount
         viewModelScope.launch {
             _uiState.value = CommentUiState.Loading
             when (val result = getCommentsUseCase(videoId)) {
@@ -102,6 +106,9 @@ class CommentViewModel @Inject constructor(
                     _comments.value = _comments.value.map {
                         if (it.tempId == tempId) result.data.copy(status = CommentStatus.SUCCESS, tempId = tempId) else it
                     }
+                    // Notify interaction manager to update comment count in feed
+                    interactionManager.notifyCommentAdded(videoId, currentCommentCount)
+                    currentCommentCount++
                     onComplete()
                 }
                 is Resource.Error -> {

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/HomeViewModel.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/HomeViewModel.kt
@@ -1,7 +1,6 @@
 package com.app.douyin.pro.feature.home.viewmodel
 
 import android.util.Log
-import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.app.douyin.pro.feature.home.domain.model.VideoModel
@@ -10,7 +9,8 @@ import com.app.douyin.pro.feature.home.domain.usecase.GetVideosUseCase
 import com.app.douyin.pro.feature.home.domain.usecase.LoadMoreVideosUseCase
 import com.app.douyin.pro.lib.media.model.AppError
 import com.app.douyin.pro.lib.media.model.Resource
-import com.app.douyin.pro.lib.media.network.DouyinApiService
+import com.app.douyin.pro.lib.media.interaction.VideoInteractionManager
+import com.app.douyin.pro.lib.media.interaction.InteractionEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -41,12 +41,8 @@ data class HomeUiState(
 class HomeViewModel @Inject constructor(
     private val getVideosUseCase: GetVideosUseCase,
     private val loadMoreVideosUseCase: LoadMoreVideosUseCase,
-    private val apiService: DouyinApiService
+    private val interactionManager: VideoInteractionManager
 ) : ViewModel() {
-
-    companion object {
-        private const val TAG = "HomeViewModel"
-    }
 
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
@@ -56,18 +52,59 @@ class HomeViewModel @Inject constructor(
 
     init {
         loadInitialData()
+        observeInteractions()
+    }
+
+    private fun observeInteractions() {
+        viewModelScope.launch {
+            interactionManager.interactionEvents.collect { event ->
+                val currentVideos = _uiState.value.videos.toMutableList()
+                when (event) {
+                    is InteractionEvent.LikeChanged -> {
+                        val index = currentVideos.indexOfFirst { it.id == event.videoId }
+                        if (index != -1) {
+                            currentVideos[index] = currentVideos[index].copy(
+                                isLiked = event.isLiked,
+                                likeCount = event.newLikeCount
+                            )
+                            _uiState.value = _uiState.value.copy(videos = currentVideos)
+                        }
+                    }
+                    is InteractionEvent.FollowChanged -> {
+                        // Update all videos from this author
+                        var changed = false
+                        currentVideos.forEachIndexed { index, video ->
+                            if (video.authorId == event.authorId) {
+                                currentVideos[index] = video.copy(isFollowed = event.isFollowed)
+                                changed = true
+                            }
+                        }
+                        if (changed) {
+                            _uiState.value = _uiState.value.copy(videos = currentVideos)
+                        }
+                    }
+                    is InteractionEvent.CommentAdded -> {
+                        val index = currentVideos.indexOfFirst { it.id == event.videoId }
+                        if (index != -1) {
+                            currentVideos[index] = currentVideos[index].copy(
+                                commentCount = event.newCommentCount
+                            )
+                            _uiState.value = _uiState.value.copy(videos = currentVideos)
+                        }
+                    }
+                }
+            }
+        }
     }
 
     fun loadInitialData() {
         if (_uiState.value.loadState is LoadState.Loading) return
 
         viewModelScope.launch {
-            // Log.d(TAG, "loadInitialData: starting")
             _uiState.value = _uiState.value.copy(loadState = LoadState.Loading)
             when (val result = getVideosUseCase()) {
                 is Resource.Success -> {
                     val page = result.data
-                    // Log.d(TAG, "loadInitialData success: videos=${page.videos.size}, nextTime=${page.nextTime}")
                     _uiState.value = _uiState.value.copy(
                         videos = page.videos,
                         loadState = LoadState.Success(isEmpty = page.videos.isEmpty())
@@ -76,7 +113,6 @@ class HomeViewModel @Inject constructor(
                     lastRequestedTime = null
                 }
                 is Resource.Error -> {
-                    // Log.e(TAG, "loadInitialData error: ${result.message}")
                     _uiState.value = _uiState.value.copy(
                         loadState = LoadState.Error(result.message, result.error)
                     )
@@ -91,24 +127,18 @@ class HomeViewModel @Inject constructor(
     fun loadMore() {
         val currentState = _uiState.value
         if (currentState.pagingState is PagingState.Loading) {
-            // Log.d(TAG, "loadMore: already loading, ignore")
             return
         }
 
-        // Boundary protection: if nextTime is null and we already have data, it means no more data
         if (nextTime == null && currentState.videos.isNotEmpty()) {
-            // Log.d(TAG, "loadMore: nextTime is null, no more data")
             return
         }
 
-        // Prevent redundant requests for the same timestamp
         if (nextTime != null && nextTime == lastRequestedTime) {
-            // Log.w(TAG, "loadMore: nextTime $nextTime is same as lastRequestedTime, potential loop, ignore")
             return
         }
 
         viewModelScope.launch {
-            // Log.d(TAG, "loadMore: starting with nextTime=$nextTime")
             _uiState.value = currentState.copy(pagingState = PagingState.Loading)
             lastRequestedTime = nextTime
 
@@ -118,17 +148,10 @@ class HomeViewModel @Inject constructor(
                     val newVideos = page.videos
                     val currentVideos = _uiState.value.videos.toMutableList()
 
-                    // Deduplication logic
                     val existingIds = currentVideos.map { it.id }.toSet()
                     val uniqueNewVideos = newVideos.filter { it.id !in existingIds }
 
-                    // if (uniqueNewVideos.size < newVideos.size) {
-                    //     Log.d(TAG, "loadMore: deduplicated ${newVideos.size - uniqueNewVideos.size} videos")
-                    // }
-
                     currentVideos.addAll(uniqueNewVideos)
-
-                    // Log.d(TAG, "loadMore success: added ${uniqueNewVideos.size} videos, total=${currentVideos.size}, nextTime=${page.nextTime}")
 
                     _uiState.value = _uiState.value.copy(
                         videos = currentVideos,
@@ -137,11 +160,9 @@ class HomeViewModel @Inject constructor(
                     nextTime = page.nextTime
                 }
                 is Resource.Error -> {
-                    // Log.e(TAG, "loadMore error: ${result.message}")
                     _uiState.value = _uiState.value.copy(
                         pagingState = PagingState.Error(result.message)
                     )
-                    // Reset lastRequestedTime on error so it can be retried
                     lastRequestedTime = null
                 }
                 else -> {
@@ -152,83 +173,12 @@ class HomeViewModel @Inject constructor(
     }
 
     fun toggleLike(videoId: Long) {
-        val currentVideos = _uiState.value.videos.toMutableList()
-        val index = currentVideos.indexOfFirst { it.id == videoId }
-        if (index != -1) {
-            val video = currentVideos[index]
-            val newIsLiked = !video.isLiked
-
-            // Optimistic update
-            currentVideos[index] = video.copy(
-                isLiked = newIsLiked,
-                likeCount = adjustCount(video.likeCount, if (newIsLiked) 1 else -1)
-            )
-            _uiState.value = _uiState.value.copy(videos = currentVideos)
-
-            // Send to backend
-            viewModelScope.launch {
-                try {
-                    val actionType = if (newIsLiked) 1 else 2
-                    val response = apiService.favoriteAction(videoId, actionType)
-                    if (response.statusCode != 0) {
-                        revertLike(videoId, video)
-                    }
-                } catch (e: Exception) {
-                    revertLike(videoId, video)
-                }
-            }
-        }
-    }
-
-    private fun revertLike(videoId: Long, originalVideo: VideoModel) {
-        val currentVideos = _uiState.value.videos.toMutableList()
-        val index = currentVideos.indexOfFirst { it.id == videoId }
-        if (index != -1) {
-            currentVideos[index] = originalVideo
-            _uiState.value = _uiState.value.copy(videos = currentVideos)
-        }
-    }
-
-    private fun adjustCount(countStr: String, delta: Int): String {
-        if (countStr.contains("w")) return countStr // Too lazy to parse "1.2w", keep it as is
-        return try {
-            val num = countStr.toInt()
-            (num + delta).toString()
-        } catch (e: Exception) {
-            countStr
-        }
+        val video = _uiState.value.videos.find { it.id == videoId } ?: return
+        interactionManager.toggleLike(videoId, video.isLiked, video.likeCount)
     }
 
     fun toggleFollow(videoId: Long) {
-        val currentVideos = _uiState.value.videos.toMutableList()
-        val index = currentVideos.indexOfFirst { it.id == videoId }
-        if (index != -1) {
-            val video = currentVideos[index]
-            val newIsFollowed = !video.isFollowed
-
-            currentVideos[index] = video.copy(isFollowed = newIsFollowed)
-            _uiState.value = _uiState.value.copy(videos = currentVideos)
-
-            viewModelScope.launch {
-                try {
-                    val actionType = if (newIsFollowed) 1 else 2
-                    val response = apiService.relationAction(video.authorId, actionType)
-                    if (response.statusCode != 0) {
-                        revertFollow(videoId, video)
-                    }
-                } catch (e: Exception) {
-                    revertFollow(videoId, video)
-                }
-            }
-        }
-    }
-
-    private fun revertFollow(videoId: Long, originalVideo: VideoModel) {
-        val currentVideos = _uiState.value.videos.toMutableList()
-        val index = currentVideos.indexOfFirst { it.id == videoId }
-        if (index != -1) {
-            currentVideos[index] = originalVideo
-            _uiState.value = _uiState.value.copy(videos = currentVideos)
-        }
+        val video = _uiState.value.videos.find { it.id == videoId } ?: return
+        interactionManager.toggleFollow(video.authorId, video.isFollowed)
     }
 }

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/SearchViewModel.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/SearchViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.app.douyin.pro.feature.home.domain.model.VideoModel
 import com.app.douyin.pro.feature.home.domain.usecase.SearchVideosUseCase
 import com.app.douyin.pro.lib.media.model.Resource
+import com.app.douyin.pro.lib.media.interaction.VideoInteractionManager
+import com.app.douyin.pro.lib.media.interaction.InteractionEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -13,7 +15,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SearchViewModel @Inject constructor(
-    private val searchVideosUseCase: SearchVideosUseCase
+    private val searchVideosUseCase: SearchVideosUseCase,
+    private val interactionManager: VideoInteractionManager
 ) : ViewModel() {
 
     private val _searchResults = MutableStateFlow<List<VideoModel>>(emptyList())
@@ -28,6 +31,51 @@ class SearchViewModel @Inject constructor(
     private var nextCursor: Long = 0L
     private var hasMore: Boolean = true
     private var currentKeyword: String = ""
+
+    init {
+        observeInteractions()
+    }
+
+    private fun observeInteractions() {
+        viewModelScope.launch {
+            interactionManager.interactionEvents.collect { event ->
+                val currentResults = _searchResults.value.toMutableList()
+                when (event) {
+                    is InteractionEvent.LikeChanged -> {
+                        val index = currentResults.indexOfFirst { it.id == event.videoId }
+                        if (index != -1) {
+                            currentResults[index] = currentResults[index].copy(
+                                isLiked = event.isLiked,
+                                likeCount = event.newLikeCount
+                            )
+                            _searchResults.value = currentResults
+                        }
+                    }
+                    is InteractionEvent.FollowChanged -> {
+                        var changed = false
+                        currentResults.forEachIndexed { index, video ->
+                            if (video.authorId == event.authorId) {
+                                currentResults[index] = video.copy(isFollowed = event.isFollowed)
+                                changed = true
+                            }
+                        }
+                        if (changed) {
+                            _searchResults.value = currentResults
+                        }
+                    }
+                    is InteractionEvent.CommentAdded -> {
+                        val index = currentResults.indexOfFirst { it.id == event.videoId }
+                        if (index != -1) {
+                            currentResults[index] = currentResults[index].copy(
+                                commentCount = event.newCommentCount
+                            )
+                            _searchResults.value = currentResults
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     fun search(keyword: String) {
         if (keyword.isBlank()) return
@@ -67,5 +115,15 @@ class SearchViewModel @Inject constructor(
             }
             _isLoading.value = false
         }
+    }
+
+    fun toggleLike(videoId: Long) {
+        val video = _searchResults.value.find { it.id == videoId } ?: return
+        interactionManager.toggleLike(videoId, video.isLiked, video.likeCount)
+    }
+
+    fun toggleFollow(videoId: Long) {
+        val video = _searchResults.value.find { it.id == videoId } ?: return
+        interactionManager.toggleFollow(video.authorId, video.isFollowed)
     }
 }

--- a/DouyinLite/feature_home/src/test/java/com/app/douyin/pro/feature/home/domain/usecase/GetVideosUseCaseTest.kt
+++ b/DouyinLite/feature_home/src/test/java/com/app/douyin/pro/feature/home/domain/usecase/GetVideosUseCaseTest.kt
@@ -28,8 +28,8 @@ class GetVideosUseCaseTest {
     @Test
     fun `invoke should return videos from repository`() = runBlocking {
         val mockVideos = listOf(
-            VideoModel(1L, "video1", "", "title1", 1L, "author1", null, "0", "0", "0", false, false),
-            VideoModel(2L, "video2", "", "title2", 2L, "author2", null, "0", "0", "0", false, false)
+            VideoModel(1L, "video1", "", "title1", 1L, "author1", null, 0L, 0L, 0L, false, false),
+            VideoModel(2L, "video2", "", "title2", 2L, "author2", null, 0L, 0L, 0L, false, false)
         )
         val mockPage = VideoPage(mockVideos, 123L)
         `when`(mockRepository.getInitialVideos()).thenReturn(Resource.Success(mockPage))

--- a/DouyinLite/feature_home/src/test/java/com/app/douyin/pro/feature/home/domain/usecase/LoadMoreVideosUseCaseTest.kt
+++ b/DouyinLite/feature_home/src/test/java/com/app/douyin/pro/feature/home/domain/usecase/LoadMoreVideosUseCaseTest.kt
@@ -29,7 +29,7 @@ class LoadMoreVideosUseCaseTest {
     fun `invoke should return more videos from repository`() = runBlocking {
         val nextTime = 123L
         val mockVideos = listOf(
-            VideoModel(3L, "video3", "", "title3", 3L, "author3", null, "0", "0", "0", false, false)
+            VideoModel(3L, "video3", "", "title3", 3L, "author3", null, 0L, 0L, 0L, false, false)
         )
         val mockPage = VideoPage(mockVideos, 456L)
         `when`(mockRepository.loadMoreVideos(nextTime)).thenReturn(Resource.Success(mockPage))

--- a/DouyinLite/feature_home/src/test/java/com/app/douyin/pro/feature/home/viewmodel/HomeViewModelTest.kt
+++ b/DouyinLite/feature_home/src/test/java/com/app/douyin/pro/feature/home/viewmodel/HomeViewModelTest.kt
@@ -5,18 +5,18 @@ import com.app.douyin.pro.feature.home.domain.model.VideoPage
 import com.app.douyin.pro.feature.home.domain.usecase.GetVideosUseCase
 import com.app.douyin.pro.feature.home.domain.usecase.LoadMoreVideosUseCase
 import com.app.douyin.pro.lib.media.model.Resource
-import com.app.douyin.pro.lib.media.network.DouyinApiService
+import com.app.douyin.pro.lib.media.interaction.VideoInteractionManager
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.*
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatchers.anyLong
 
 @ExperimentalCoroutinesApi
 class HomeViewModelTest {
@@ -24,13 +24,14 @@ class HomeViewModelTest {
     private lateinit var viewModel: HomeViewModel
     private val getVideosUseCase: GetVideosUseCase = mock(GetVideosUseCase::class.java)
     private val loadMoreVideosUseCase: LoadMoreVideosUseCase = mock(LoadMoreVideosUseCase::class.java)
-    private val apiService: DouyinApiService = mock(DouyinApiService::class.java)
+    private val interactionManager: VideoInteractionManager = mock(VideoInteractionManager::class.java)
 
     private val testDispatcher = StandardTestDispatcher()
 
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
+        `when`(interactionManager.interactionEvents).thenReturn(MutableSharedFlow())
     }
 
     @After
@@ -40,11 +41,11 @@ class HomeViewModelTest {
 
     @Test
     fun `loadInitialData success updates state with videos`() = runTest {
-        val videos = listOf(VideoModel(1, "p1", "c1", "t1", 101, "a1", "av1", "1", "1", "1", false, false))
+        val videos = listOf(VideoModel(1, "p1", "c1", "t1", 101, "a1", "av1", 1L, 1L, 1L, false, false))
         val page = VideoPage(videos, 123L)
         `when`(getVideosUseCase()).thenReturn(Resource.Success(page))
 
-        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, apiService)
+        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, interactionManager)
         testDispatcher.scheduler.advanceUntilIdle()
 
         val state = viewModel.uiState.value
@@ -58,7 +59,7 @@ class HomeViewModelTest {
         val errorMessage = "Network Error"
         `when`(getVideosUseCase()).thenReturn(Resource.Error(errorMessage))
 
-        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, apiService)
+        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, interactionManager)
         testDispatcher.scheduler.advanceUntilIdle()
 
         val state = viewModel.uiState.value
@@ -68,15 +69,15 @@ class HomeViewModelTest {
 
     @Test
     fun `loadMore success appends videos to state`() = runTest {
-        val video1 = VideoModel(1, "p1", "c1", "t1", 101, "a1", "av1", "1", "1", "1", false, false)
-        val video2 = VideoModel(2, "p2", "c2", "t2", 102, "a2", "av2", "2", "2", "2", false, false)
+        val video1 = VideoModel(1, "p1", "c1", "t1", 101, "a1", "av1", 1L, 1L, 1L, false, false)
+        val video2 = VideoModel(2, "p2", "c2", "t2", 102, "a2", "av2", 2L, 2L, 2L, false, false)
         val initialPage = VideoPage(listOf(video1), 123L)
         val nextPage = VideoPage(listOf(video2), 456L)
 
         `when`(getVideosUseCase()).thenReturn(Resource.Success(initialPage))
         `when`(loadMoreVideosUseCase(123L)).thenReturn(Resource.Success(nextPage))
 
-        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, apiService)
+        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, interactionManager)
         testDispatcher.scheduler.advanceUntilIdle()
 
         viewModel.loadMore()
@@ -90,14 +91,14 @@ class HomeViewModelTest {
 
     @Test
     fun `loadMore failure updates pagingState with error`() = runTest {
-        val video1 = VideoModel(1, "p1", "c1", "t1", 101, "a1", "av1", "1", "1", "1", false, false)
+        val video1 = VideoModel(1, "p1", "c1", "t1", 101, "a1", "av1", 1L, 1L, 1L, false, false)
         val initialPage = VideoPage(listOf(video1), 123L)
         val errorMessage = "Paging Error"
 
         `when`(getVideosUseCase()).thenReturn(Resource.Success(initialPage))
         `when`(loadMoreVideosUseCase(123L)).thenReturn(Resource.Error(errorMessage))
 
-        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, apiService)
+        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, interactionManager)
         testDispatcher.scheduler.advanceUntilIdle()
 
         viewModel.loadMore()
@@ -111,8 +112,8 @@ class HomeViewModelTest {
 
     @Test
     fun `loadMore with duplicate videos should deduplicate`() = runTest {
-        val video1 = VideoModel(1, "p1", "c1", "t1", 101, "a1", "av1", "1", "1", "1", false, false)
-        val video2 = VideoModel(2, "p2", "c2", "t2", 102, "a2", "av2", "2", "2", "2", false, false)
+        val video1 = VideoModel(1, "p1", "c1", "t1", 101, "a1", "av1", 1L, 1L, 1L, false, false)
+        val video2 = VideoModel(2, "p2", "c2", "t2", 102, "a2", "av2", 2L, 2L, 2L, false, false)
 
         val initialPage = VideoPage(listOf(video1), 123L)
         // video1 is repeated in the second page
@@ -121,7 +122,7 @@ class HomeViewModelTest {
         `when`(getVideosUseCase()).thenReturn(Resource.Success(initialPage))
         `when`(loadMoreVideosUseCase(123L)).thenReturn(Resource.Success(nextPage))
 
-        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, apiService)
+        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, interactionManager)
         testDispatcher.scheduler.advanceUntilIdle()
 
         viewModel.loadMore()
@@ -134,20 +135,17 @@ class HomeViewModelTest {
 
     @Test
     fun `loadMore with null nextTime should not trigger request`() = runTest {
-        val video1 = VideoModel(1, "p1", "c1", "t1", 101, "a1", "av1", "1", "1", "1", false, false)
+        val video1 = VideoModel(1, "p1", "c1", "t1", 101, "a1", "av1", 1L, 1L, 1L, false, false)
         val initialPage = VideoPage(listOf(video1), null)
 
         `when`(getVideosUseCase()).thenReturn(Resource.Success(initialPage))
 
-        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, apiService)
+        viewModel = HomeViewModel(getVideosUseCase, loadMoreVideosUseCase, interactionManager)
         testDispatcher.scheduler.advanceUntilIdle()
 
         viewModel.loadMore()
         testDispatcher.scheduler.advanceUntilIdle()
 
-        // loadMoreVideosUseCase should not have been called
-        // We can't easily verify with mockito in this setup without more boilerplate,
-        // but we can check state remains Idle and videos didn't change.
         val state = viewModel.uiState.value
         assertEquals(1, state.videos.size)
         assertTrue(state.pagingState is PagingState.Idle)

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/interaction/VideoInteractionManager.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/interaction/VideoInteractionManager.kt
@@ -1,0 +1,82 @@
+package com.app.douyin.pro.lib.media.interaction
+
+import com.app.douyin.pro.lib.media.network.DouyinApiService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+sealed class InteractionEvent {
+    data class LikeChanged(val videoId: Long, val isLiked: Boolean, val newLikeCount: Long) : InteractionEvent()
+    data class FollowChanged(val authorId: Long, val isFollowed: Boolean) : InteractionEvent()
+    data class CommentAdded(val videoId: Long, val newCommentCount: Long) : InteractionEvent()
+}
+
+@Singleton
+class VideoInteractionManager @Inject constructor(
+    private val apiService: DouyinApiService
+) {
+    private val _interactionEvents = MutableSharedFlow<InteractionEvent>(extraBufferCapacity = 64)
+    val interactionEvents = _interactionEvents.asSharedFlow()
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    fun toggleLike(videoId: Long, currentIsLiked: Boolean, currentLikeCount: Long) {
+        val newIsLiked = !currentIsLiked
+        val newLikeCount = if (newIsLiked) currentLikeCount + 1 else (currentLikeCount - 1).coerceAtLeast(0)
+
+        // Optimistic update
+        scope.launch {
+            _interactionEvents.emit(InteractionEvent.LikeChanged(videoId, newIsLiked, newLikeCount))
+        }
+
+        // Backend call
+        scope.launch {
+            try {
+                val actionType = if (newIsLiked) 1 else 2
+                val response = apiService.favoriteAction(videoId, actionType)
+                if (response.statusCode != 0) {
+                    // Rollback
+                    _interactionEvents.emit(InteractionEvent.LikeChanged(videoId, currentIsLiked, currentLikeCount))
+                }
+            } catch (e: Exception) {
+                // Rollback
+                _interactionEvents.emit(InteractionEvent.LikeChanged(videoId, currentIsLiked, currentLikeCount))
+            }
+        }
+    }
+
+    fun toggleFollow(authorId: Long, currentIsFollowed: Boolean) {
+        val newIsFollowed = !currentIsFollowed
+
+        // Optimistic update
+        scope.launch {
+            _interactionEvents.emit(InteractionEvent.FollowChanged(authorId, newIsFollowed))
+        }
+
+        // Backend call
+        scope.launch {
+            try {
+                val actionType = if (newIsFollowed) 1 else 2
+                val response = apiService.relationAction(authorId, actionType)
+                if (response.statusCode != 0) {
+                    // Rollback
+                    _interactionEvents.emit(InteractionEvent.FollowChanged(authorId, currentIsFollowed))
+                }
+            } catch (e: Exception) {
+                // Rollback
+                _interactionEvents.emit(InteractionEvent.FollowChanged(authorId, currentIsFollowed))
+            }
+        }
+    }
+
+    fun notifyCommentAdded(videoId: Long, currentCommentCount: Long) {
+        scope.launch {
+            _interactionEvents.emit(InteractionEvent.CommentAdded(videoId, currentCommentCount + 1))
+        }
+    }
+}

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/util/CountFormatter.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/util/CountFormatter.kt
@@ -1,0 +1,13 @@
+package com.app.douyin.pro.lib.media.util
+
+import java.util.Locale
+
+object CountFormatter {
+    fun format(count: Long): String {
+        return when {
+            count >= 100_000_000 -> String.format(Locale.getDefault(), "%.1f亿", count / 100_000_000.0)
+            count >= 10_000 -> String.format(Locale.getDefault(), "%.1fw", count / 10_000.0)
+            else -> count.toString()
+        }
+    }
+}


### PR DESCRIPTION
This change addresses the P0 issue regarding interaction state and count inconsistencies. 

Key improvements:
1. **Centralized Interaction Logic**: A new `VideoInteractionManager` singleton acts as the single source of truth for video interactions. It handles optimistic updates (emitted immediately to the UI) and failure rollbacks (reverting to the original state if the API fails).
2. **Cross-Screen Synchronization**: Both `HomeViewModel` and `SearchViewModel` observe the same `interactionEvents` stream, ensuring that liking a video or following an author in one screen is immediately reflected in the other.
3. **Robust Count Handling**: `VideoModel` now stores counts as `Long` values instead of strings. Arithmetic operations are now reliable, and display formatting is centralized in a new `CountFormatter` utility.
4. **Comment Count Accuracy**: Posting a comment now correctly increments the comment count on the video feed via the interaction manager.
5. **Unit Test Stability**: Refactored existing tests in `feature_home` to align with the new architecture, ensuring long-term maintainability.

Fixes #51

---
*PR created automatically by Jules for task [224023455582103657](https://jules.google.com/task/224023455582103657) started by @zx2121651*