### PR TITLE
Rollback and Cleanup for Video Publishing

### DIFF
--- a/DouyinBackend/biz/dal/db/init.go
+++ b/DouyinBackend/biz/dal/db/init.go
@@ -39,7 +39,7 @@ func Init() {
 	DB.Exec("PRAGMA synchronous=NORMAL;")
 
 	// Migrate the schema
-	err = DB.AutoMigrate(&model.User{}, &model.Video{}, &model.Favorite{}, &model.Comment{}, &model.Relation{}, &model.Message{})
+	err = DB.AutoMigrate(&model.User{}, &model.Video{}, &model.Favorite{}, &model.Comment{}, &model.Relation{}, &model.Message{}, &model.SystemNotification{})
 	if err != nil {
 		panic("failed to migrate database")
 	}

--- a/DouyinBackend/biz/handler/video/publish_handler.go
+++ b/DouyinBackend/biz/handler/video/publish_handler.go
@@ -75,8 +75,9 @@ func PublishAction(ctx context.Context, c *app.RequestContext) {
 	placeholderCoverURL := "https://images.unsplash.com/photo-1611162617474-5b21e879e113"
 
 	// 先将视频及占位封面存入数据库
-	if err := videoService.PublishVideo(userID, req.Title, playURL, placeholderCoverURL); err != nil {
-		os.Remove(savePath)
+	video, err := videoService.PublishVideo(userID, req.Title, playURL, placeholderCoverURL)
+	if err != nil {
+		storageService.DeleteFile(savePath)
 		c.JSON(consts.StatusInternalServerError, video_model.PublishActionResponse{
 			BaseResponse: common.BaseResponse{
 				StatusCode: 1,
@@ -87,12 +88,25 @@ func PublishAction(ctx context.Context, c *app.RequestContext) {
 	}
 
 	// 开启 goroutine 异步截取真实封面并更新数据库
-	go func(vPath, cName, pURL string) {
+	go func(vID uint, vPath, cName, pURL string) {
 		actualCoverURL, err := storageService.GenerateCover(vPath, cName)
-		if err == nil && actualCoverURL != "" {
-			videoService.UpdateCoverByURL(pURL, actualCoverURL)
+		if err != nil {
+			// 异步处理失败，执行回滚
+			storageService.DeleteFile(vPath)
+			videoService.DeleteVideo(vID)
+			return
 		}
-	}(savePath, coverFilename, playURL)
+
+		if err := videoService.UpdateVideoStatusAndCover(vID, "published", actualCoverURL); err != nil {
+			// 数据库更新失败，执行回滚
+			storageService.DeleteFile(vPath)
+			// 尝试删除已生成的封面文件
+			coverPath := filepath.Join(config.GlobalConfig.Storage.Local.CoverPath, cName)
+			storageService.DeleteFile(coverPath)
+			videoService.DeleteVideo(vID)
+			return
+		}
+	}(video.ID, savePath, coverFilename, playURL)
 
 	c.JSON(consts.StatusOK, video_model.PublishActionResponse{
 		BaseResponse: common.BaseResponse{

--- a/DouyinBackend/biz/service/storage/storage_service.go
+++ b/DouyinBackend/biz/service/storage/storage_service.go
@@ -29,11 +29,9 @@ func (s *StorageService) GenerateCover(videoPath string, coverName string) (stri
 	cmd := exec.Command("ffmpeg", "-y", "-i", videoPath, "-ss", "00:00:01", "-vframes", "1", coverPath)
 
 	// If FFmpeg is not installed in the environment, this will fail.
-	// For production, ensure FFmpeg is available. For development, we can mock it if it fails.
+	// For production, ensure FFmpeg is available.
 	if err := cmd.Run(); err != nil {
-		// Mock a cover if FFmpeg fails (e.g. not installed locally)
-		// return "", fmt.Errorf("ffmpeg generate cover failed: %v", err)
-		return "https://images.unsplash.com/photo-1611162617474-5b21e879e113", nil
+		return "", fmt.Errorf("ffmpeg generate cover failed: %v", err)
 	}
 
 	// Generate local URL for the cover
@@ -55,6 +53,14 @@ func (s *StorageService) BuildAvatarURL(filename string) string {
 		return fmt.Sprintf("http://%s/static/avatars/%s", config.GlobalConfig.Storage.Local.Domain, filename)
 	}
 	return ""
+}
+
+// DeleteFile deletes a file from the local file system
+func (s *StorageService) DeleteFile(path string) error {
+	if path == "" {
+		return nil
+	}
+	return os.Remove(path)
 }
 
 func (s *StorageService) BuildBackgroundURL(filename string) string {

--- a/DouyinBackend/biz/service/video_service.go
+++ b/DouyinBackend/biz/service/video_service.go
@@ -94,7 +94,7 @@ func (s *VideoService) GetFeed(latestTime int64, limit int, currentUserID uint) 
 	return videos, nextTime, nil
 }
 
-func (s *VideoService) PublishVideo(authorID uint, title string, playURL string, coverURL string) error {
+func (s *VideoService) PublishVideo(authorID uint, title string, playURL string, coverURL string) (*model.Video, error) {
 	// Step 1: Immediately persist the video as "processing" to ensure the user gets a fast response
 	video := model.Video{
 		AuthorID:      authorID,
@@ -108,34 +108,10 @@ func (s *VideoService) PublishVideo(authorID uint, title string, playURL string,
 	}
 
 	if err := db.DB.Create(&video).Error; err != nil {
-		return err
+		return nil, err
 	}
 
-	// Step 2: Spin off a Goroutine to handle asynchronous media post-processing and checks
-	go func(vid uint, uid uint) {
-		// Simulate network extraction, FFmpeg transcoding delay, and content safety moderation
-		time.Sleep(3 * time.Second)
-
-		// After processing, update the status to "published" safely inside a transaction
-		db.DB.Transaction(func(tx *gorm.DB) error {
-			if err := tx.Model(&model.Video{}).Where("id = ?", vid).Update("status", "published").Error; err != nil {
-				return err
-			}
-
-			// Generate a system notification to the author confirming successful processing
-			notif := model.SystemNotification{
-				ToUserID:   uid,
-				Type:       model.NotificationTypeSystem,
-				Content:    "您的视频《" + title + "》已发布成功",
-				TargetID:   vid,
-			}
-			tx.Create(&notif)
-
-			return nil
-		})
-	}(video.ID, authorID)
-
-	return nil
+	return &video, nil
 }
 
 func (s *VideoService) GetPublishList(userID uint) ([]model.Video, error) {
@@ -170,6 +146,46 @@ func (s *VideoService) RecordVideoView(videoID uint, userID uint) error {
 	}
 
 	return nil
+}
+
+// UpdateVideoStatusAndCover updates the status and cover URL of a video.
+// This is used by the asynchronous processing.
+func (s *VideoService) UpdateVideoStatusAndCover(vid uint, status string, coverURL string) error {
+	return db.DB.Transaction(func(tx *gorm.DB) error {
+		var video model.Video
+		if err := tx.First(&video, vid).Error; err != nil {
+			return err
+		}
+
+		updates := map[string]interface{}{
+			"status":    status,
+			"cover_url": coverURL,
+		}
+
+		if err := tx.Model(&video).Updates(updates).Error; err != nil {
+			return err
+		}
+
+		if status == "published" {
+			// Generate a system notification to the author confirming successful processing
+			notif := model.SystemNotification{
+				ToUserID: video.AuthorID,
+				Type:     model.NotificationTypeSystem,
+				Content:  "您的视频《" + video.Title + "》已发布成功",
+				TargetID: video.ID,
+			}
+			if err := tx.Create(&notif).Error; err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+// DeleteVideo deletes a video record from the database.
+func (s *VideoService) DeleteVideo(vid uint) error {
+	return db.DB.Delete(&model.Video{}, vid).Error
 }
 
 // UpdateCoverByURL updates the cover URL of a video by its play URL.

--- a/DouyinBackend/biz/service/video_service_test.go
+++ b/DouyinBackend/biz/service/video_service_test.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/douyin/backend/biz/common/config"
+	"github.com/douyin/backend/biz/dal/db"
+	"github.com/douyin/backend/biz/service/storage"
+	"github.com/douyin/backend/biz/dal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVideoRollback(t *testing.T) {
+	// Initialize config and DB for test
+	config.GlobalConfig = &config.Config{
+		Database: config.DatabaseConfig{
+			DSN: ":memory:",
+		},
+		Storage: config.StorageConfig{
+			Local: config.LocalConfig{
+				VideoPath: "./test_videos",
+				CoverPath: "./test_covers",
+			},
+		},
+	}
+	db.Init()
+
+	videoService := NewVideoService()
+	storageService := storage.NewStorageService()
+
+	t.Run("TestDeleteVideo", func(t *testing.T) {
+		video, err := videoService.PublishVideo(1, "test title", "play_url", "cover_url")
+		assert.NoError(t, err)
+		assert.NotNil(t, video)
+
+		err = videoService.DeleteVideo(video.ID)
+		assert.NoError(t, err)
+
+		var count int64
+		db.DB.Model(&model.Video{}).Where("id = ?", video.ID).Count(&count)
+		// It should be 1 if it's soft deleted, but let's check Unscoped
+		db.DB.Unscoped().Model(&model.Video{}).Where("id = ?", video.ID).Count(&count)
+		assert.Equal(t, int64(1), count)
+
+		db.DB.Model(&model.Video{}).Where("id = ?", video.ID).Count(&count)
+		assert.Equal(t, int64(0), count)
+	})
+
+	t.Run("TestDeleteFile", func(t *testing.T) {
+		err := os.MkdirAll("./test_videos", 0755)
+		assert.NoError(t, err)
+		defer os.RemoveAll("./test_videos")
+
+		filePath := filepath.Join("./test_videos", "test_file.txt")
+		err = os.WriteFile(filePath, []byte("test content"), 0644)
+		assert.NoError(t, err)
+
+		err = storageService.DeleteFile(filePath)
+		assert.NoError(t, err)
+
+		_, err = os.Stat(filePath)
+		assert.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("TestUpdateVideoStatusAndCover", func(t *testing.T) {
+		video, err := videoService.PublishVideo(1, "test title", "play_url", "placeholder")
+		assert.NoError(t, err)
+
+		err = videoService.UpdateVideoStatusAndCover(video.ID, "published", "actual_cover")
+		assert.NoError(t, err)
+
+		var updatedVideo model.Video
+		db.DB.First(&updatedVideo, video.ID)
+		assert.Equal(t, "published", updatedVideo.Status)
+		assert.Equal(t, "actual_cover", updatedVideo.CoverURL)
+	})
+}

--- a/DouyinBackend/go.mod
+++ b/DouyinBackend/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/joho/godotenv v1.5.1
 	github.com/spf13/viper v1.21.0
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.22.0
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.1
@@ -21,6 +22,7 @@ require (
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cloudwego/gopkg v0.1.10 // indirect
 	github.com/cloudwego/netpoll v0.7.2 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
@@ -28,6 +30,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
@@ -43,4 +46,5 @@ require (
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Established a robust failure compensation mechanism for the video publishing workflow. 

Key changes include:
1. **Storage Layer**: Added `DeleteFile` and updated `GenerateCover` to return errors on FFmpeg failure, ensuring we don't proceed with "blurry" states.
2. **Service Layer**: Simplified `PublishVideo` to a pure database insertion. Added `UpdateVideoStatusAndCover` to handle finalization (status change + notification) atomically and `DeleteVideo` for cleanup.
3. **Handler Layer**: Orchestrated the rollback logic. If initial DB insertion fails, the uploaded file is cleaned up. If asynchronous processing (cover generation or final update) fails, both the files and the database record are rolled back.
4. **Database**: Included `SystemNotification` in the auto-migration to prevent transactional failures during status updates.
5. **Testing**: Added unit tests in `video_service_test.go` to verify that rollback and cleanup work as intended.

Fixes #55

---
*PR created automatically by Jules for task [14437984872566000660](https://jules.google.com/task/14437984872566000660) started by @zx2121651*