### PR TITLE
Establish NDK build foundation and HardwareDecoder minimal closed loop

### DIFF
--- a/DouyinLite/lib_media/src/main/cpp/CMakeLists.txt
+++ b/DouyinLite/lib_media/src/main/cpp/CMakeLists.txt
@@ -1,15 +1,30 @@
 cmake_minimum_required(VERSION 3.22.1)
 project("douyin_core")
 
+# Define project-wide includes
+include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/common
+    ${CMAKE_CURRENT_SOURCE_DIR}/player
+    ${CMAKE_CURRENT_SOURCE_DIR}/core
+)
+
+# Core library sources
+set(DOUYIN_CORE_SOURCES
+    JniOnLoad.cpp
+    player/HardwareDecoder.cpp
+    player/HardwareDecoderJni.cpp
+)
+
 add_library(
-        douyin_core
-        SHARED
-        JniOnLoad.cpp
+    douyin_core
+    SHARED
+    ${DOUYIN_CORE_SOURCES}
 )
 
 target_link_libraries(
-        douyin_core
-        log
-        mediandk
-        android
+    douyin_core
+    log
+    mediandk
+    android
 )

--- a/DouyinLite/lib_media/src/main/cpp/README.md
+++ b/DouyinLite/lib_media/src/main/cpp/README.md
@@ -1,0 +1,39 @@
+# DouyinLite Native Media Base
+
+This directory contains the NDK (Native Development Kit) components for the DouyinLite media module.
+
+## Directory Structure
+
+- `common/`: Shared utilities and headers (e.g., `Log.h`).
+- `core/`: Low-level primitives (e.g., `SpinLock.h`, `LockFreeRingBuffer.h`).
+- `player/`: Media player components and hardware decoder logic.
+- `CMakeLists.txt`: Build configuration for the `douyin_core` shared library.
+- `JniOnLoad.cpp`: JNI initialization and library entry point.
+
+## Key Components
+
+### HardwareDecoder
+A wrapper around the Android NDK `AMediaCodec` and `ANativeWindow` APIs.
+- **Location**: `player/HardwareDecoder.h` and `player/HardwareDecoder.cpp`.
+- **Functionality**: Minimal lifecycle for initialization, configuration, rendering, and resource release.
+- **JNI Bridge**: `player/HardwareDecoderJni.cpp` and `NativeHardwareDecoder.kt`.
+
+## Lifecycle and Memory Management
+
+- **Object Creation**: Native objects are created via JNI and returned as a `jlong` (pointer) to the Java layer.
+- **Ownership**: The Java class `NativeHardwareDecoder` holds the reference to the native object.
+- **Cleanup**: Resources MUST be released by calling `release()` on the Java object, which triggers `delete` on the native pointer. A `finalize()` method is provided as a safety net.
+- **Thread Safety**: Currently, the `HardwareDecoder` is not thread-safe by design; synchronization should be handled by the caller or evolved in future iterations.
+
+## Error Handling
+
+- **Logging**: Use the macros in `common/Log.h` (`LOGI`, `LOGE`, etc.) for consistent logging under the `DouyinNative` tag.
+- **Return Values**: JNI methods return `jboolean` or other status indicators to propagate failures to the Java layer.
+- **Crashes**: Parameter validation is performed at both JNI and C++ levels to prevent NULL pointer dereferences and native crashes.
+
+## Future Evolution
+
+1. **Demuxer Integration**: Add NDK `AMediaExtractor` support.
+2. **Rendering Pipeline**: Integrate OpenGL/Vulkan for post-processing and display.
+3. **Audio Sync**: Implement clock synchronization for A/V playback.
+4. **FBO 管线**: Support Frame Buffer Objects for advanced effects.

--- a/DouyinLite/lib_media/src/main/cpp/common/Log.h
+++ b/DouyinLite/lib_media/src/main/cpp/common/Log.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <android/log.h>
+
+#define LOG_TAG "DouyinNative"
+
+#define LOGV(...) __android_log_print(ANDROID_LOG_VERBOSE, LOG_TAG, __VA_ARGS__)
+#define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
+#define LOGW(...) __android_log_print(ANDROID_LOG_WARN, LOG_TAG, __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)

--- a/DouyinLite/lib_media/src/main/cpp/player/HardwareDecoder.cpp
+++ b/DouyinLite/lib_media/src/main/cpp/player/HardwareDecoder.cpp
@@ -1,0 +1,109 @@
+#include "HardwareDecoder.h"
+#include "../common/Log.h"
+#include <media/NdkMediaFormat.h>
+
+namespace douyin {
+namespace player {
+
+HardwareDecoder::HardwareDecoder() : mCodec(nullptr), mWindow(nullptr), mIsConfigured(false) {
+    LOGD("HardwareDecoder: Constructor called");
+}
+
+HardwareDecoder::~HardwareDecoder() {
+    LOGD("HardwareDecoder: Destructor called");
+    Release();
+}
+
+bool HardwareDecoder::Init() {
+    LOGD("HardwareDecoder: Init called");
+    // Currently, Init is a placeholder for any pre-configuration logic
+    return true;
+}
+
+bool HardwareDecoder::Configure(const char* mimeType, int width, int height, ANativeWindow* window) {
+    LOGI("HardwareDecoder: Configure(mime=%s, width=%d, height=%d)", mimeType, width, height);
+
+    if (mIsConfigured) {
+        LOGW("HardwareDecoder: Already configured, releasing previous resources");
+        Release();
+    }
+
+    if (!mimeType || width <= 0 || height <= 0) {
+        LOGE("HardwareDecoder: Invalid parameters for configuration");
+        return false;
+    }
+
+    mWindow = window;
+    if (mWindow) {
+        ANativeWindow_acquire(mWindow);
+    }
+
+    mCodec = AMediaCodec_createDecoderByType(mimeType);
+    if (!mCodec) {
+        LOGE("HardwareDecoder: Failed to create decoder for mime type: %s", mimeType);
+        return false;
+    }
+
+    AMediaFormat* format = AMediaFormat_new();
+    AMediaFormat_setString(format, AMEDIAFORMAT_KEY_MIME, mimeType);
+    AMediaFormat_setInt32(format, AMEDIAFORMAT_KEY_WIDTH, width);
+    AMediaFormat_setInt32(format, AMEDIAFORMAT_KEY_HEIGHT, height);
+
+    media_status_t status = AMediaCodec_configure(mCodec, format, mWindow, nullptr, 0);
+    AMediaFormat_delete(format);
+
+    if (status != AMEDIA_OK) {
+        LOGE("HardwareDecoder: AMediaCodec_configure failed with status: %d", status);
+        Release();
+        return false;
+    }
+
+    status = AMediaCodec_start(mCodec);
+    if (status != AMEDIA_OK) {
+        LOGE("HardwareDecoder: AMediaCodec_start failed with status: %d", status);
+        Release();
+        return false;
+    }
+
+    mIsConfigured = true;
+    LOGI("HardwareDecoder: Configured successfully");
+    return true;
+}
+
+void HardwareDecoder::RenderOutputBufferToSurface(int timeoutUs) {
+    if (!mIsConfigured || !mCodec) {
+        return;
+    }
+
+    AMediaCodecBufferInfo info;
+    ssize_t outIndex = AMediaCodec_dequeueOutputBuffer(mCodec, &info, timeoutUs);
+    if (outIndex >= 0) {
+        // Render to surface if mWindow was provided during Configure
+        AMediaCodec_releaseOutputBuffer(mCodec, outIndex, true);
+    } else if (outIndex == AMEDIACODEC_INFO_OUTPUT_FORMAT_CHANGED) {
+        LOGD("HardwareDecoder: Output format changed");
+    } else if (outIndex == AMEDIACODEC_INFO_OUTPUT_BUFFERS_CHANGED) {
+        LOGD("HardwareDecoder: Output buffers changed");
+    } else if (outIndex == AMEDIACODEC_INFO_TRY_AGAIN_LATER) {
+        // No buffer available
+    } else {
+        LOGW("HardwareDecoder: Dequeue output buffer returned: %zd", outIndex);
+    }
+}
+
+void HardwareDecoder::Release() {
+    LOGD("HardwareDecoder: Release called");
+    if (mCodec) {
+        AMediaCodec_stop(mCodec);
+        AMediaCodec_delete(mCodec);
+        mCodec = nullptr;
+    }
+    if (mWindow) {
+        ANativeWindow_release(mWindow);
+        mWindow = nullptr;
+    }
+    mIsConfigured = false;
+}
+
+} // namespace player
+} // namespace douyin

--- a/DouyinLite/lib_media/src/main/cpp/player/HardwareDecoder.h
+++ b/DouyinLite/lib_media/src/main/cpp/player/HardwareDecoder.h
@@ -9,55 +9,19 @@ class HardwareDecoder {
 private:
     AMediaCodec* mCodec;
     ANativeWindow* mWindow;
-    bool isConfigured;
+    bool mIsConfigured;
 
 public:
-    HardwareDecoder() : mCodec(nullptr), mWindow(nullptr), isConfigured(false) {}
-    ~HardwareDecoder() {
-        if (mCodec) {
-            AMediaCodec_stop(mCodec);
-            AMediaCodec_delete(mCodec);
-        }
-        if (mWindow) {
-            ANativeWindow_release(mWindow);
-        }
-    }
+    HardwareDecoder();
+    ~HardwareDecoder();
 
-    bool AttachWindow(JNIEnv* env, jobject surface) {
-        if (mWindow) ANativeWindow_release(mWindow);
-        mWindow = ANativeWindow_fromSurface(env, surface);
-        return mWindow != nullptr;
-    }
+    bool Init();
+    bool Configure(const char* mimeType, int width, int height, ANativeWindow* window);
+    void RenderOutputBufferToSurface(int timeoutUs);
+    void Release();
 
-    bool ConfigureDecoder(const char* mimeType, int width, int height) {
-        mCodec = AMediaCodec_createDecoderByType(mimeType);
-        if (!mCodec) return false;
-
-        AMediaFormat* format = AMediaFormat_new();
-        AMediaFormat_setString(format, AMEDIAFORMAT_KEY_MIME, mimeType);
-        AMediaFormat_setInt32(format, AMEDIAFORMAT_KEY_WIDTH, width);
-        AMediaFormat_setInt32(format, AMEDIAFORMAT_KEY_HEIGHT, height);
-
-        media_status_t status = AMediaCodec_configure(mCodec, format, mWindow, nullptr, 0);
-        AMediaFormat_delete(format);
-
-        if (status == AMEDIA_OK) {
-            AMediaCodec_start(mCodec);
-            isConfigured = true;
-            return true;
-        }
-        return false;
-    }
-
-    void RenderOutputBufferToSurface(int timeoutUs) {
-        if (!isConfigured) return;
-        AMediaCodecBufferInfo info;
-        ssize_t outIndex = AMediaCodec_dequeueOutputBuffer(mCodec, &info, timeoutUs);
-        if (outIndex >= 0) {
-            // 硬核零拷贝：将画面直接渲染到 EGL Surface
-            AMediaCodec_releaseOutputBuffer(mCodec, outIndex, true);
-        }
-    }
+    // Helper to get AMediaCodec pointer if needed for future extensions
+    AMediaCodec* GetCodec() const { return mCodec; }
 };
 
 } // namespace player

--- a/DouyinLite/lib_media/src/main/cpp/player/HardwareDecoderJni.cpp
+++ b/DouyinLite/lib_media/src/main/cpp/player/HardwareDecoderJni.cpp
@@ -1,0 +1,72 @@
+#include <jni.h>
+#include <android/native_window_jni.h>
+#include <new>
+#include "HardwareDecoder.h"
+#include "../common/Log.h"
+
+using namespace douyin::player;
+
+extern "C"
+JNIEXPORT jlong JNICALL
+Java_com_app_douyin_pro_lib_media_NativeHardwareDecoder_nativeCreate(JNIEnv *env, jobject thiz) {
+    auto* decoder = new (std::nothrow) HardwareDecoder();
+    if (!decoder) {
+        LOGE("JNI: Failed to allocate HardwareDecoder");
+        return 0;
+    }
+    LOGD("JNI: nativeCreate success, ptr=%p", decoder);
+    return reinterpret_cast<jlong>(decoder);
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_com_app_douyin_pro_lib_media_NativeHardwareDecoder_nativeInit(JNIEnv *env, jobject thiz, jlong ptr) {
+    auto* decoder = reinterpret_cast<HardwareDecoder*>(ptr);
+    if (!decoder) return JNI_FALSE;
+    return decoder->Init() ? JNI_TRUE : JNI_FALSE;
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_com_app_douyin_pro_lib_media_NativeHardwareDecoder_nativeConfigure(JNIEnv *env, jobject thiz,
+                                                                       jlong ptr, jstring mime_type,
+                                                                       jint width, jint height,
+                                                                       jobject surface) {
+    auto* decoder = reinterpret_cast<HardwareDecoder*>(ptr);
+    if (!decoder) return JNI_FALSE;
+
+    const char* mime = env->GetStringUTFChars(mime_type, nullptr);
+    ANativeWindow* window = nullptr;
+    if (surface) {
+        window = ANativeWindow_fromSurface(env, surface);
+    }
+
+    bool success = decoder->Configure(mime, width, height, window);
+
+    if (window) {
+        ANativeWindow_release(window); // HardwareDecoder::Configure will acquire its own reference if needed
+    }
+    env->ReleaseStringUTFChars(mime_type, mime);
+
+    return success ? JNI_TRUE : JNI_FALSE;
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_app_douyin_pro_lib_media_NativeHardwareDecoder_nativeRender(JNIEnv *env, jobject thiz,
+                                                                    jlong ptr, jint timeout_us) {
+    auto* decoder = reinterpret_cast<HardwareDecoder*>(ptr);
+    if (decoder) {
+        decoder->RenderOutputBufferToSurface(timeout_us);
+    }
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_app_douyin_pro_lib_media_NativeHardwareDecoder_nativeRelease(JNIEnv *env, jobject thiz, jlong ptr) {
+    auto* decoder = reinterpret_cast<HardwareDecoder*>(ptr);
+    if (decoder) {
+        LOGD("JNI: nativeRelease, ptr=%p", decoder);
+        delete decoder;
+    }
+}

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/NativeHardwareDecoder.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/NativeHardwareDecoder.kt
@@ -1,0 +1,68 @@
+package com.app.douyin.pro.lib.media
+
+import android.view.Surface
+
+/**
+ * Kotlin interface for the native hardware decoder.
+ * Manages the lifecycle of a native HardwareDecoder instance.
+ */
+class NativeHardwareDecoder {
+    // Pointer to the native HardwareDecoder object
+    private var nativePtr: Long = 0
+
+    companion object {
+        init {
+            System.loadLibrary("douyin_core")
+        }
+    }
+
+    /**
+     * Creates and initializes the native decoder instance.
+     */
+    fun init(): Boolean {
+        if (nativePtr != 0L) return true
+        nativePtr = nativeCreate()
+        return if (nativePtr != 0L) {
+            nativeInit(nativePtr)
+        } else {
+            false
+        }
+    }
+
+    /**
+     * Configures the decoder with the given parameters and target surface.
+     */
+    fun configure(mimeType: String, width: Int, height: Int, surface: Surface?): Boolean {
+        if (nativePtr == 0L) return false
+        return nativeConfigure(nativePtr, mimeType, width, height, surface)
+    }
+
+    /**
+     * Triggers rendering of the next available output buffer to the surface.
+     */
+    fun render(timeoutUs: Int) {
+        if (nativePtr != 0L) {
+            nativeRender(nativePtr, timeoutUs)
+        }
+    }
+
+    /**
+     * Releases the native decoder and its resources.
+     */
+    fun release() {
+        if (nativePtr != 0L) {
+            nativeRelease(nativePtr)
+            nativePtr = 0
+        }
+    }
+
+    protected fun finalize() {
+        release()
+    }
+
+    private external fun nativeCreate(): Long
+    private external fun nativeInit(ptr: Long): Boolean
+    private external fun nativeConfigure(ptr: Long, mimeType: String, width: Int, height: Int, surface: Surface?): Boolean
+    private external fun nativeRender(ptr: Long, timeoutUs: Int)
+    private external fun nativeRelease(ptr: Long)
+}

--- a/DouyinLite/lib_media/src/test/java/com/app/douyin/pro/lib/media/NativeHardwareDecoderTest.kt
+++ b/DouyinLite/lib_media/src/test/java/com/app/douyin/pro/lib/media/NativeHardwareDecoderTest.kt
@@ -1,0 +1,37 @@
+package com.app.douyin.pro.lib.media
+
+import org.junit.Test
+import org.junit.Assert.*
+
+/**
+ * Unit test for NativeHardwareDecoder.
+ * Note: Actual native method execution requires a device/emulator.
+ * This test verifies class loading and basic signature visibility.
+ */
+class NativeHardwareDecoderTest {
+
+    @Test
+    fun testClassLoading() {
+        try {
+            val decoder = NativeHardwareDecoder()
+            assertNotNull(decoder)
+        } catch (e: UnsatisfiedLinkError) {
+            // Expected when running on host without native library
+            println("UnsatisfiedLinkError caught as expected on host: ${e.message}")
+        }
+    }
+
+    @Test
+    fun testLifecycleMethodsExist() {
+        // This test mostly ensures the Kotlin code compiles and the class can be instantiated
+        // (if the native library were present)
+        val clazz = NativeHardwareDecoder::class.java
+        val methods = clazz.declaredMethods
+        val methodNames = methods.map { it.name }
+
+        assertTrue(methodNames.contains("init"))
+        assertTrue(methodNames.contains("configure"))
+        assertTrue(methodNames.contains("render"))
+        assertTrue(methodNames.contains("release"))
+    }
+}


### PR DESCRIPTION
This PR establishes the foundational NDK build infrastructure for the `lib_media` module and implements a minimal "closed loop" for the native `HardwareDecoder`.

Key changes include:
- **NDK Structure**: Organized native code into `common`, `core`, and `player` directories.
- **Logging**: Introduced a unified `Log.h` for native logging using the `DouyinNative` tag.
- **HardwareDecoder**: Refactored the previous skeleton into a functional C++ class that wraps `AMediaCodec` and `ANativeWindow`, supporting basic lifecycle methods.
- **JNI Bridge**: Implemented `NativeHardwareDecoder.kt` and its corresponding C++ JNI bridge, ensuring safe pointer-based lifecycle management.
- **Documentation**: Added a `README.md` in the native source directory explaining the architecture, lifecycle conventions, and future roadmap.
- **Verification**: Included a unit test to verify JNI method visibility and confirmed that the module compiles successfully for all supported architectures.

This base provides the necessary infrastructure for future implementation of demuxing, rendering pipelines, and the full native player core.

Fixes #61

---
*PR created automatically by Jules for task [3205852538743642309](https://jules.google.com/task/3205852538743642309) started by @zx2121651*