### PR TITLE
Unified Search State Model and Suggestions

### DIFF
--- a/DouyinBackend/biz/handler/search/search_handler.go
+++ b/DouyinBackend/biz/handler/search/search_handler.go
@@ -72,6 +72,36 @@ func SearchVideo(ctx context.Context, c *app.RequestContext) {
 	})
 }
 
+func HotWords(ctx context.Context, c *app.RequestContext) {
+	words, err := searchService.GetHotWords()
+	if err != nil {
+		utils.SendResponse(c, err, nil)
+		return
+	}
+
+	utils.SendResponse(c, errno.Success, map[string]interface{}{
+		"words": words,
+	})
+}
+
+func Suggest(ctx context.Context, c *app.RequestContext) {
+	var req search_model.SuggestRequest
+	if err := c.BindAndValidate(&req); err != nil {
+		utils.SendResponse(c, errno.ParamErr.WithMessage(err.Error()), nil)
+		return
+	}
+
+	suggestions, err := searchService.GetSuggestions(req.Keyword)
+	if err != nil {
+		utils.SendResponse(c, err, nil)
+		return
+	}
+
+	utils.SendResponse(c, errno.Success, map[string]interface{}{
+		"suggestions": suggestions,
+	})
+}
+
 func SearchUser(ctx context.Context, c *app.RequestContext) {
 	var currentUserID uint = 0
 	if rawID, exists := c.Get("user_id"); exists {

--- a/DouyinBackend/biz/model/search/search_api.go
+++ b/DouyinBackend/biz/model/search/search_api.go
@@ -27,3 +27,17 @@ type SearchUserResponse struct {
 	NextCursor int64       `json:"next_cursor"`
 	HasMore    bool        `json:"has_more"`
 }
+
+type HotWordsResponse struct {
+	common.BaseResponse
+	Words []string `json:"words"`
+}
+
+type SuggestRequest struct {
+	Keyword string `query:"keyword" vd:"$!='';msg:'keyword is required'"`
+}
+
+type SuggestResponse struct {
+	common.BaseResponse
+	Suggestions []string `json:"suggestions"`
+}

--- a/DouyinBackend/biz/router/router.go
+++ b/DouyinBackend/biz/router/router.go
@@ -58,6 +58,8 @@ func Register(h *server.Hertz) {
 	searchGroup := api.Group("/search")
 	searchGroup.GET("/video/", mw.SoftAuthMiddleware(), search.SearchVideo)
 	searchGroup.GET("/user/", mw.SoftAuthMiddleware(), search.SearchUser)
+	searchGroup.GET("/hot_words/", search.HotWords)
+	searchGroup.GET("/suggest/", search.Suggest)
 
 	// Effect
 	effectGroup := api.Group("/effect")

--- a/DouyinBackend/biz/service/search_service.go
+++ b/DouyinBackend/biz/service/search_service.go
@@ -65,3 +65,52 @@ func (s *SearchService) SearchUsers(keyword string, offset int, limit int) ([]mo
 
 	return users, nil
 }
+
+// GetHotWords returns a list of trending search terms
+func (s *SearchService) GetHotWords() ([]string, error) {
+	// For now, we return a static list of hot words.
+	// In a real scenario, this would come from a cache or a separate analytics service.
+	return []string{
+		"杭州亚运会",
+		"国庆假期旅游攻略",
+		"iPhone 15 发布",
+		"程序员的一天",
+		"猫咪卖萌瞬间",
+		"硬核科技评测",
+		"抖音电影榜",
+		"秋天的第一杯奶茶",
+	}, nil
+}
+
+// GetSuggestions returns a list of search suggestions based on the keyword
+func (s *SearchService) GetSuggestions(keyword string) ([]string, error) {
+	var suggestions []string
+
+	// Suggestion logic: search for video titles starting with the keyword
+	// or containing the keyword, limited to 10 results.
+	query := `
+		SELECT DISTINCT title
+		FROM videos
+		WHERE videos.deleted_at IS NULL AND videos.title LIKE ?
+		LIMIT 10
+	`
+	if err := db.DB.Raw(query, keyword+"%").Scan(&suggestions).Error; err != nil {
+		return nil, err
+	}
+
+	// If not enough suggestions from titles, we could also add from usernames or other sources
+	if len(suggestions) < 10 {
+		var userNames []string
+		userQuery := `
+			SELECT DISTINCT name
+			FROM users
+			WHERE users.deleted_at IS NULL AND (users.name LIKE ? OR users.username LIKE ?)
+			LIMIT ?
+		`
+		if err := db.DB.Raw(userQuery, keyword+"%", keyword+"%", 10-len(suggestions)).Scan(&userNames).Error; err == nil {
+			suggestions = append(suggestions, userNames...)
+		}
+	}
+
+	return suggestions, nil
+}

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/data/SearchRepository.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/data/SearchRepository.kt
@@ -50,6 +50,36 @@ class SearchRepository @Inject constructor(
         }
     }
 
+    suspend fun getHotWords(): Resource<List<String>> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = remoteDataSource.getHotWords()
+                if (response.statusCode == 0) {
+                    Resource.Success(response.words ?: emptyList())
+                } else {
+                    Resource.Error(response.statusMsg ?: "Failed to get hot words")
+                }
+            } catch (e: Exception) {
+                Resource.Error(e.message ?: "Unknown Error")
+            }
+        }
+    }
+
+    suspend fun getSuggestions(keyword: String): Resource<List<String>> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = remoteDataSource.getSuggestions(keyword)
+                if (response.statusCode == 0) {
+                    Resource.Success(response.suggestions ?: emptyList())
+                } else {
+                    Resource.Error(response.statusMsg ?: "Failed to get suggestions")
+                }
+            } catch (e: Exception) {
+                Resource.Error(e.message ?: "Unknown Error")
+            }
+        }
+    }
+
     suspend fun searchUsers(keyword: String, cursor: Long): Resource<Pair<List<UserModel>, Long>> {
         return withContext(Dispatchers.IO) {
             try {

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/data/source/SearchDataSource.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/data/source/SearchDataSource.kt
@@ -1,8 +1,10 @@
 package com.app.douyin.pro.feature.home.data.source
 
 import com.app.douyin.pro.lib.media.network.DouyinApiService
+import com.app.douyin.pro.lib.media.network.model.HotWordsResponse
 import com.app.douyin.pro.lib.media.network.model.SearchUserResponse
 import com.app.douyin.pro.lib.media.network.model.SearchVideoResponse
+import com.app.douyin.pro.lib.media.network.model.SuggestResponse
 import javax.inject.Inject
 
 class SearchDataSource @Inject constructor(
@@ -14,5 +16,13 @@ class SearchDataSource @Inject constructor(
 
     suspend fun searchUsers(keyword: String, cursor: Long): SearchUserResponse {
         return apiService.searchUser(keyword = keyword, cursor = cursor)
+    }
+
+    suspend fun getHotWords(): HotWordsResponse {
+        return apiService.getHotWords()
+    }
+
+    suspend fun getSuggestions(keyword: String): SuggestResponse {
+        return apiService.getSuggestions(keyword)
     }
 }

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/SearchScreen.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/SearchScreen.kt
@@ -51,7 +51,7 @@ fun SearchScreen(
     val selectedTab by viewModel.selectedTab.collectAsState()
     val videoResults by viewModel.videoResults.collectAsState()
     val userResults by viewModel.userResults.collectAsState()
-    val history by viewModel.searchHistory.collectAsState()
+    val combinedSuggestions by viewModel.combinedSuggestions.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
 
     Column(
@@ -72,22 +72,10 @@ fun SearchScreen(
 
         Box(modifier = Modifier.weight(1f)) {
             when (val state = uiState) {
-                is SearchUiState.Idle -> {
-                    SearchIdleContent(
-                        history = history,
-                        onHistoryClick = {
-                            searchQuery = it
-                            viewModel.search(it)
-                        },
-                        onDeleteHistory = { viewModel.deleteHistory(it) },
-                        onClearHistory = { viewModel.clearHistory() }
-                    )
-                }
-                is SearchUiState.Searching -> {
-                    // Could show suggestions here, currently just empty or same as idle
-                    SearchIdleContent(
-                        history = history,
-                        onHistoryClick = {
+                is SearchUiState.Idle, is SearchUiState.Suggesting -> {
+                    UnifiedSearchSuggestions(
+                        suggestions = combinedSuggestions,
+                        onItemClick = {
                             searchQuery = it
                             viewModel.search(it)
                         },
@@ -201,88 +189,144 @@ fun SearchTopBar(
 }
 
 @Composable
-fun SearchIdleContent(
-    history: List<String>,
-    onHistoryClick: (String) -> Unit,
+fun UnifiedSearchSuggestions(
+    suggestions: List<com.app.douyin.pro.feature.home.viewmodel.SearchSuggestion>,
+    onItemClick: (String) -> Unit,
     onDeleteHistory: (String) -> Unit,
     onClearHistory: () -> Unit
 ) {
+    val history = suggestions.filter { it.type == com.app.douyin.pro.feature.home.viewmodel.SuggestionType.HISTORY }
+    val hot = suggestions.filter { it.type == com.app.douyin.pro.feature.home.viewmodel.SuggestionType.HOT }
+    val suggests = suggestions.filter { it.type == com.app.douyin.pro.feature.home.viewmodel.SuggestionType.SUGGEST }
+
     LazyColumn(modifier = Modifier.fillMaxSize()) {
-        if (history.isNotEmpty()) {
-            item {
+        if (suggests.isNotEmpty()) {
+            items(suggests) { suggest ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(16.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
+                        .clickable { onItemClick(suggest.content) }
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text("搜索历史", color = Color.White, fontSize = 14.sp, fontWeight = FontWeight.Bold)
                     Icon(
-                        Icons.Default.Delete,
-                        contentDescription = "Clear All",
+                        Icons.Default.Search,
+                        contentDescription = null,
                         tint = Color.Gray,
-                        modifier = Modifier
-                            .size(16.dp)
-                            .clickable { onClearHistory() }
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = suggest.content,
+                        color = Color.White,
+                        fontSize = 15.sp
                     )
                 }
+                Divider(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    color = Color(0xFF2B2C33),
+                    thickness = 0.5.dp
+                )
             }
-            item {
-                FlowRow(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
-                    mainAxisSpacing = 8.dp,
-                    crossAxisSpacing = 8.dp
-                ) {
-                    history.forEach { item ->
-                        Box(
+        } else {
+            if (history.isNotEmpty()) {
+                item {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text("搜索历史", color = Color.White, fontSize = 14.sp, fontWeight = FontWeight.Bold)
+                        Icon(
+                            Icons.Default.Delete,
+                            contentDescription = "Clear All",
+                            tint = Color.Gray,
                             modifier = Modifier
-                                .clip(RoundedCornerShape(4.dp))
-                                .background(Color(0xFF2B2C33))
-                                .clickable { onHistoryClick(item) }
-                                .padding(horizontal = 12.dp, vertical = 6.dp)
-                        ) {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Text(item, color = Color.LightGray, fontSize = 13.sp)
-                                // Optional: delete icon per item
+                                .size(16.dp)
+                                .clickable { onClearHistory() }
+                        )
+                    }
+                }
+                item {
+                    FlowRow(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        mainAxisSpacing = 8.dp,
+                        crossAxisSpacing = 8.dp
+                    ) {
+                        history.forEach { item ->
+                            Box(
+                                modifier = Modifier
+                                    .clip(RoundedCornerShape(4.dp))
+                                    .background(Color(0xFF2B2C33))
+                                    .clickable { onItemClick(item.content) }
+                                    .padding(horizontal = 12.dp, vertical = 6.dp)
+                            ) {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Text(item.content, color = Color.LightGray, fontSize = 13.sp)
+                                    Spacer(modifier = Modifier.width(4.dp))
+                                    Icon(
+                                        Icons.Default.Close,
+                                        contentDescription = "Delete",
+                                        tint = Color.Gray,
+                                        modifier = Modifier
+                                            .size(12.dp)
+                                            .clickable { onDeleteHistory(item.content) }
+                                    )
+                                }
                             }
                         }
                     }
                 }
             }
-        }
 
-        item {
-            Text(
-                "猜你想搜",
-                color = Color.White,
-                fontSize = 14.sp,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(16.dp)
-            )
-        }
-
-        val recommendations = listOf("热点新闻", "搞笑视频", "美食教程", "旅游攻略", "科技数码", "电影推荐")
-        item {
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(2),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(120.dp)
-                    .padding(horizontal = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-                userScrollEnabled = false
-            ) {
-                items(recommendations) { item ->
+            if (hot.isNotEmpty()) {
+                item {
                     Text(
-                        item,
-                        color = Color.LightGray,
+                        "猜你想搜",
+                        color = Color.White,
                         fontSize = 14.sp,
-                        modifier = Modifier.clickable { onHistoryClick(item) }
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.padding(16.dp)
                     )
+                }
+
+                item {
+                    // Use a Box with custom layout or just a Column of Rows to avoid hardcoded height of LazyVerticalGrid
+                    Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                        val chunks = hot.chunked(2)
+                        chunks.forEach { rowItems ->
+                            Row(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp)) {
+                                rowItems.forEach { item ->
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        modifier = Modifier.weight(1f).clickable { onItemClick(item.content) }
+                                    ) {
+                                        Icon(
+                                            Icons.Default.TrendingUp,
+                                            contentDescription = null,
+                                            tint = Color(0xFFFE2C55),
+                                            modifier = Modifier.size(14.dp)
+                                        )
+                                        Spacer(modifier = Modifier.width(8.dp))
+                                        Text(
+                                            item.content,
+                                            color = Color.LightGray,
+                                            fontSize = 14.sp,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis
+                                        )
+                                    }
+                                }
+                                if (rowItems.size == 1) {
+                                    Spacer(modifier = Modifier.weight(1f))
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/SearchViewModel.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/SearchViewModel.kt
@@ -8,22 +8,31 @@ import com.app.douyin.pro.feature.home.domain.usecase.SearchVideosUseCase
 import com.app.douyin.pro.lib.media.interaction.InteractionEvent
 import com.app.douyin.pro.lib.media.interaction.VideoInteractionManager
 import com.app.douyin.pro.lib.media.model.Resource
+import com.app.douyin.pro.feature.home.data.SearchRepository
 import com.app.douyin.pro.lib.media.model.UserModel
 import com.app.douyin.pro.lib.media.model.VideoModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 sealed class SearchUiState {
     object Idle : SearchUiState()
-    object Searching : SearchUiState()
+    object Suggesting : SearchUiState()
     object Results : SearchUiState()
     object Empty : SearchUiState()
     data class Error(val message: String) : SearchUiState()
 }
+
+enum class SuggestionType {
+    HISTORY, HOT, SUGGEST
+}
+
+data class SearchSuggestion(
+    val content: String,
+    val type: SuggestionType
+)
 
 enum class SearchResultType {
     Video, User
@@ -33,6 +42,7 @@ enum class SearchResultType {
 class SearchViewModel @Inject constructor(
     private val searchVideosUseCase: SearchVideosUseCase,
     private val searchUsersUseCase: SearchUsersUseCase,
+    private val searchRepository: SearchRepository,
     private val interactionManager: VideoInteractionManager,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
@@ -52,7 +62,11 @@ class SearchViewModel @Inject constructor(
     val userResults: StateFlow<List<UserModel>> = _userResults
 
     private val _searchHistory = MutableStateFlow<List<String>>(loadHistory())
-    val searchHistory: StateFlow<List<String>> = _searchHistory
+    private val _hotWords = MutableStateFlow<List<String>>(emptyList())
+    private val _suggestions = MutableStateFlow<List<String>>(emptyList())
+
+    private val _combinedSuggestions = MutableStateFlow<List<SearchSuggestion>>(emptyList())
+    val combinedSuggestions: StateFlow<List<SearchSuggestion>> = _combinedSuggestions
 
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading
@@ -63,9 +77,77 @@ class SearchViewModel @Inject constructor(
     private var hasMoreUsers: Boolean = true
     private var currentKeyword: String = ""
 
+    private val _queryFlow = MutableStateFlow("")
+
     init {
         observeInteractions()
+        observeQuery()
+        loadHotWords()
     }
+
+    @OptIn(kotlinx.coroutines.FlowPreview::class, kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    private fun observeQuery() {
+        viewModelScope.launch {
+            _queryFlow
+                .debounce(300L)
+                .distinctUntilChanged()
+                .flatMapLatest { query ->
+                    flow {
+                        if (query.isBlank()) {
+                            emit(emptyList<String>())
+                        } else {
+                            val result = searchRepository.getSuggestions(query)
+                            if (result is Resource.Success) {
+                                emit(result.data)
+                            } else {
+                                emit(emptyList<String>())
+                            }
+                        }
+                    }
+                }
+                .collect { suggestions ->
+                    _suggestions.value = suggestions
+                }
+        }
+
+        // Also observe history and hot words to update combined suggestions
+        viewModelScope.launch {
+            combine(_searchHistory, _hotWords, _suggestions, _queryFlow) { history, hot, suggest, query ->
+                buildCombinedSuggestions(history, hot, suggest, query)
+            }.collect {
+                _combinedSuggestions.value = it
+            }
+        }
+    }
+
+    private fun buildCombinedSuggestions(
+        history: List<String>,
+        hot: List<String>,
+        suggest: List<String>,
+        query: String
+    ): List<SearchSuggestion> {
+        return if (query.isEmpty()) {
+            val result = mutableListOf<SearchSuggestion>()
+            history.forEach { result.add(SearchSuggestion(it, SuggestionType.HISTORY)) }
+            hot.forEach { result.add(SearchSuggestion(it, SuggestionType.HOT)) }
+            result
+        } else {
+            suggest.map { SearchSuggestion(it, SuggestionType.SUGGEST) }
+        }
+    }
+
+
+    private fun loadHotWords() {
+        viewModelScope.launch {
+            when (val result = searchRepository.getHotWords()) {
+                is Resource.Success -> {
+                    _hotWords.value = result.data
+                }
+                else -> {}
+            }
+        }
+    }
+
 
     private fun observeInteractions() {
         viewModelScope.launch {
@@ -120,10 +202,19 @@ class SearchViewModel @Inject constructor(
     }
 
     fun onQueryChanged(query: String) {
+        val oldQuery = _queryFlow.value
+        _queryFlow.value = query
+
+        // If we were in Results state and user starts editing, move back to Suggesting
+        if (query != oldQuery && _uiState.value is SearchUiState.Results) {
+            _uiState.value = SearchUiState.Suggesting
+        }
+
         if (query.isEmpty()) {
             _uiState.value = SearchUiState.Idle
+            _suggestions.value = emptyList()
         } else if (_uiState.value is SearchUiState.Idle) {
-            _uiState.value = SearchUiState.Searching
+            _uiState.value = SearchUiState.Suggesting
         }
     }
 
@@ -187,7 +278,7 @@ class SearchViewModel @Inject constructor(
                 }
                 is Resource.Error -> {
                     if (_videoResults.value.isEmpty()) {
-                        _uiState.value = SearchUiState.Error(result.message ?: "Search failed")
+                        _uiState.value = SearchUiState.Error(result.message)
                     }
                 }
                 else -> {}
@@ -226,8 +317,12 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun loadHistory(): List<String> {
-        val historyString = prefs.getString("history_list", "") ?: ""
-        return if (historyString.isEmpty()) emptyList() else historyString.split("|")
+        val historyString = prefs.getString("history_list", "")
+        return if (historyString.isNullOrEmpty()) {
+            emptyList()
+        } else {
+            historyString.split("|").take(20)
+        }
     }
 
     private fun saveHistory(keyword: String) {

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/network/DouyinApiService.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/network/DouyinApiService.kt
@@ -14,6 +14,8 @@ import com.app.douyin.pro.lib.media.network.model.MessageChatResponse
 import com.app.douyin.pro.lib.media.network.model.MessageActionResponse
 import com.app.douyin.pro.lib.media.network.model.SearchVideoResponse
 import com.app.douyin.pro.lib.media.network.model.SearchUserResponse
+import com.app.douyin.pro.lib.media.network.model.HotWordsResponse
+import com.app.douyin.pro.lib.media.network.model.SuggestResponse
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Query
@@ -134,4 +136,12 @@ interface DouyinApiService {
         @Query("cursor") cursor: Long = 0L,
         @Query("token") token: String? = null
     ): SearchUserResponse
+
+    @GET("douyin/search/hot_words/")
+    suspend fun getHotWords(): HotWordsResponse
+
+    @GET("douyin/search/suggest/")
+    suspend fun getSuggestions(
+        @Query("keyword") keyword: String
+    ): SuggestResponse
 }

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/network/model/SearchResponse.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/network/model/SearchResponse.kt
@@ -10,6 +10,18 @@ data class SearchVideoResponse(
     @SerializedName("has_more") val hasMore: Boolean
 )
 
+data class HotWordsResponse(
+    @SerializedName("status_code") val statusCode: Int,
+    @SerializedName("status_msg") val statusMsg: String?,
+    @SerializedName("words") val words: List<String>?
+)
+
+data class SuggestResponse(
+    @SerializedName("status_code") val statusCode: Int,
+    @SerializedName("status_msg") val statusMsg: String?,
+    @SerializedName("suggestions") val suggestions: List<String>?
+)
+
 data class SearchUserResponse(
     @SerializedName("status_code") val statusCode: Int,
     @SerializedName("status_msg") val statusMsg: String?,


### PR DESCRIPTION
Established a unified state model for search history, hot words, and association words across both backend and frontend. 

Key changes:
- Backend: Added `/douyin/search/hot_words/` and `/douyin/search/suggest/` endpoints with prefix-matching logic for titles and usernames.
- Frontend: Introduced `SearchSuggestion` model and consolidated multiple state flows into a single `combinedSuggestions` Flow in `SearchViewModel`.
- Performance: Implemented debouncing and `flatMapLatest` to ensure efficient network usage and prevent race conditions.
- UI: Unified rendering logic in `SearchScreen.kt` for a consistent user experience.
- Stability: Added logic to strictly limit search history to 20 items and ensured proper state transitions during search refinement.

Fixes #78

---
*PR created automatically by Jules for task [1245164912681590246](https://jules.google.com/task/1245164912681590246) started by @zx2121651*