### PR TITLE
Implement Search Results Pagination and Player Path

### DIFF
--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/AppNavigation.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/AppNavigation.kt
@@ -103,7 +103,35 @@ fun AppNavHost(
             MallScreen(onBack = { navController.popBackStack() })
         }
         composable(NavRoutes.SEARCH) {
-            SearchScreen(onBack = { navController.popBackStack() })
+            SearchScreen(
+                onBack = { navController.popBackStack() },
+                onVideoClick = { keyword, index ->
+                    navController.navigate(NavRoutes.buildSearchPlayerRoute(keyword, index))
+                }
+            )
+        }
+        composable(
+            route = NavRoutes.SEARCH_PLAYER,
+            arguments = listOf(
+                navArgument("keyword") { type = NavType.StringType },
+                navArgument("index") { type = NavType.IntType }
+            )
+        ) { backStackEntry ->
+            val keyword = backStackEntry.arguments?.getString("keyword") ?: ""
+            val index = backStackEntry.arguments?.getInt("index") ?: 0
+
+            // Get the ViewModel from the Search Screen's backstack entry to share it
+            val searchBackStackEntry = remember(backStackEntry) {
+                navController.getBackStackEntry(NavRoutes.SEARCH)
+            }
+            val searchViewModel: com.app.douyin.pro.feature.home.viewmodel.SearchViewModel = hiltViewModel(searchBackStackEntry)
+
+            SearchPlayerScreen(
+                keyword = keyword,
+                initialIndex = index,
+                onBack = { navController.popBackStack() },
+                viewModel = searchViewModel
+            )
         }
         composable(NavRoutes.LOGIN) {
             LoginScreen(

--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/NavRoutes.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/NavRoutes.kt
@@ -25,6 +25,10 @@ object NavRoutes {
     }
 
     const val SEARCH = "search"
+    const val SEARCH_PLAYER = "search_player?keyword={keyword}&index={index}"
+    fun buildSearchPlayerRoute(keyword: String, index: Int): String {
+        return "search_player?keyword=${android.net.Uri.encode(keyword)}&index=$index"
+    }
 
     const val LOGIN = "login"
     const val REGISTER = "register"

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/SearchPlayerScreen.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/SearchPlayerScreen.kt
@@ -1,0 +1,65 @@
+package com.app.douyin.pro.feature.home.ui
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.app.douyin.pro.feature.home.ui.components.VideoFeed
+import com.app.douyin.pro.feature.home.viewmodel.SearchViewModel
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun SearchPlayerScreen(
+    keyword: String,
+    initialIndex: Int,
+    onBack: () -> Unit,
+    viewModel: SearchViewModel
+) {
+    val videoResults by viewModel.videoResults.collectAsState()
+    val pagingState by viewModel.pagingState.collectAsState()
+
+    Box(modifier = Modifier.fillMaxSize().background(Color.Black)) {
+        if (videoResults.isNotEmpty()) {
+            VideoFeed(
+                videos = videoResults,
+                isVisible = true,
+                onNavigateToProfile = { /* Navigate to profile if needed */ },
+                pagingState = pagingState,
+                initialPage = initialIndex.coerceIn(0, videoResults.size - 1),
+                onLoadMore = { viewModel.loadMore() }
+            )
+        }
+
+        // Top Bar with Back Button
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(
+                    Icons.Default.ArrowBack,
+                    contentDescription = "Back",
+                    tint = Color.White
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "搜索: $keyword",
+                color = Color.White,
+                fontSize = 16.sp,
+                style = MaterialTheme.typography.titleMedium
+            )
+        }
+    }
+}

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/SearchScreen.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/SearchScreen.kt
@@ -44,6 +44,7 @@ import com.app.douyin.pro.lib.media.util.CountFormatter
 @Composable
 fun SearchScreen(
     onBack: () -> Unit,
+    onVideoClick: (String, Int) -> Unit = { _, _ -> },
     viewModel: SearchViewModel = hiltViewModel()
 ) {
     var searchQuery by remember { mutableStateOf("") }
@@ -53,6 +54,7 @@ fun SearchScreen(
     val userResults by viewModel.userResults.collectAsState()
     val combinedSuggestions by viewModel.combinedSuggestions.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
+    val pagingState by viewModel.pagingState.collectAsState()
 
     Column(
         modifier = Modifier
@@ -90,16 +92,18 @@ fun SearchScreen(
                         videoResults = videoResults,
                         userResults = userResults,
                         isLoading = isLoading,
+                        pagingState = pagingState,
                         onLoadMore = { viewModel.loadMore() },
                         onLikeClick = { viewModel.toggleLike(it) },
-                        onFollowClick = { viewModel.toggleFollow(it) }
+                        onFollowClick = { viewModel.toggleFollow(it) },
+                        onVideoClick = { index -> onVideoClick(searchQuery, index) }
                     )
                 }
                 is SearchUiState.Empty -> {
-                    EmptySearchView()
+                    EmptySearchView(onRetry = { if (searchQuery.isNotEmpty()) viewModel.search(searchQuery) })
                 }
                 is SearchUiState.Error -> {
-                    ErrorSearchView(message = state.message, onRetry = { viewModel.search(searchQuery) })
+                    ErrorSearchView(message = state.message, onRetry = { if (searchQuery.isNotEmpty()) viewModel.search(searchQuery) })
                 }
             }
         }
@@ -356,9 +360,11 @@ fun SearchResultContent(
     videoResults: List<VideoModel>,
     userResults: List<UserModel>,
     isLoading: Boolean,
+    pagingState: com.app.douyin.pro.feature.home.viewmodel.PagingState,
     onLoadMore: () -> Unit,
     onLikeClick: (Long) -> Unit,
-    onFollowClick: (Long) -> Unit
+    onFollowClick: (Long) -> Unit,
+    onVideoClick: (Int) -> Unit
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         TabRow(
@@ -390,13 +396,16 @@ fun SearchResultContent(
                 VideoResultList(
                     videos = videoResults,
                     isLoading = isLoading,
+                    pagingState = pagingState,
                     onLoadMore = onLoadMore,
-                    onLikeClick = onLikeClick
+                    onLikeClick = onLikeClick,
+                    onVideoClick = onVideoClick
                 )
             } else {
                 UserResultList(
                     users = userResults,
                     isLoading = isLoading,
+                    pagingState = pagingState,
                     onLoadMore = onLoadMore,
                     onFollowClick = onFollowClick
                 )
@@ -409,21 +418,36 @@ fun SearchResultContent(
 fun VideoResultList(
     videos: List<VideoModel>,
     isLoading: Boolean,
+    pagingState: com.app.douyin.pro.feature.home.viewmodel.PagingState,
     onLoadMore: () -> Unit,
-    onLikeClick: (Long) -> Unit
+    onLikeClick: (Long) -> Unit,
+    onVideoClick: (Int) -> Unit
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        items(videos) { video ->
-            VideoResultItem(video = video, onLikeClick = onLikeClick)
+        items(videos.size) { index ->
+            VideoResultItem(
+                video = videos[index],
+                onLikeClick = onLikeClick,
+                onClick = { onVideoClick(index) }
+            )
         }
         item {
-            if (isLoading) {
+            if (isLoading || pagingState is com.app.douyin.pro.feature.home.viewmodel.PagingState.Loading) {
                 Box(modifier = Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
                     CircularProgressIndicator(color = Color(0xFFFE2C55), modifier = Modifier.size(24.dp))
+                }
+            } else if (pagingState is com.app.douyin.pro.feature.home.viewmodel.PagingState.Error) {
+                Box(modifier = Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                    Text(
+                        text = "加载失败，点击重试",
+                        color = Color.Gray,
+                        fontSize = 13.sp,
+                        modifier = Modifier.clickable { onLoadMore() }
+                    )
                 }
             } else if (videos.isNotEmpty()) {
                 LaunchedEffect(Unit) { onLoadMore() }
@@ -433,13 +457,14 @@ fun VideoResultList(
 }
 
 @Composable
-fun VideoResultItem(video: VideoModel, onLikeClick: (Long) -> Unit) {
+fun VideoResultItem(video: VideoModel, onLikeClick: (Long) -> Unit, onClick: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(110.dp)
             .clip(RoundedCornerShape(4.dp))
             .background(Color(0xFF252632))
+            .clickable { onClick() }
     ) {
         AsyncImage(
             model = video.coverUrl,
@@ -489,6 +514,7 @@ fun VideoResultItem(video: VideoModel, onLikeClick: (Long) -> Unit) {
 fun UserResultList(
     users: List<UserModel>,
     isLoading: Boolean,
+    pagingState: com.app.douyin.pro.feature.home.viewmodel.PagingState,
     onLoadMore: () -> Unit,
     onFollowClick: (Long) -> Unit
 ) {
@@ -501,9 +527,18 @@ fun UserResultList(
             UserResultItem(user = user, onFollowClick = onFollowClick)
         }
         item {
-            if (isLoading) {
+            if (isLoading || pagingState is com.app.douyin.pro.feature.home.viewmodel.PagingState.Loading) {
                 Box(modifier = Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
                     CircularProgressIndicator(color = Color(0xFFFE2C55), modifier = Modifier.size(24.dp))
+                }
+            } else if (pagingState is com.app.douyin.pro.feature.home.viewmodel.PagingState.Error) {
+                Box(modifier = Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                    Text(
+                        text = "加载失败，点击重试",
+                        color = Color.Gray,
+                        fontSize = 13.sp,
+                        modifier = Modifier.clickable { onLoadMore() }
+                    )
                 }
             } else if (users.isNotEmpty()) {
                 LaunchedEffect(Unit) { onLoadMore() }
@@ -546,12 +581,16 @@ fun UserResultItem(user: UserModel, onFollowClick: (Long) -> Unit) {
 }
 
 @Composable
-fun EmptySearchView() {
+fun EmptySearchView(onRetry: () -> Unit) {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Icon(Icons.Default.Search, contentDescription = null, tint = Color.Gray, modifier = Modifier.size(64.dp))
             Spacer(modifier = Modifier.height(16.dp))
             Text("未找到相关结果", color = Color.Gray, fontSize = 14.sp)
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = onRetry, colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFE2C55))) {
+                Text("重试")
+            }
         }
     }
 }

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/components/VideoFeed.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/components/VideoFeed.kt
@@ -34,9 +34,10 @@ fun VideoFeed(
     isVisible: Boolean,
     onNavigateToProfile: () -> Unit,
     pagingState: PagingState = PagingState.Idle,
+    initialPage: Int = 0,
     onLoadMore: () -> Unit = {}
 ) {
-    val pagerState = rememberPagerState(pageCount = { videos.size })
+    val pagerState = rememberPagerState(initialPage = initialPage, pageCount = { videos.size })
     val context = LocalContext.current
     val playerManager = remember { VideoPlayerManager.getInstance(context) }
 

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/CommonStates.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/CommonStates.kt
@@ -1,0 +1,7 @@
+package com.app.douyin.pro.feature.home.viewmodel
+
+sealed class PagingState {
+    object Idle : PagingState()
+    object Loading : PagingState()
+    data class Error(val message: String) : PagingState()
+}

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/HomeViewModel.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/HomeViewModel.kt
@@ -25,12 +25,6 @@ sealed class LoadState {
     data class Error(val message: String, val error: AppError? = null) : LoadState()
 }
 
-sealed class PagingState {
-    object Idle : PagingState()
-    object Loading : PagingState()
-    data class Error(val message: String) : PagingState()
-}
-
 data class HomeUiState(
     val videos: List<VideoModel> = emptyList(),
     val loadState: LoadState = LoadState.Idle,

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/SearchViewModel.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/SearchViewModel.kt
@@ -61,6 +61,9 @@ class SearchViewModel @Inject constructor(
     private val _userResults = MutableStateFlow<List<UserModel>>(emptyList())
     val userResults: StateFlow<List<UserModel>> = _userResults
 
+    private val _pagingState = MutableStateFlow<PagingState>(PagingState.Idle)
+    val pagingState: StateFlow<PagingState> = _pagingState
+
     private val _searchHistory = MutableStateFlow<List<String>>(loadHistory())
     private val _hotWords = MutableStateFlow<List<String>>(emptyList())
     private val _suggestions = MutableStateFlow<List<String>>(emptyList())
@@ -259,58 +262,90 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun loadMoreVideos() {
-        if (!hasMoreVideos || _isLoading.value) return
+        if (!hasMoreVideos || _isLoading.value || _pagingState.value is PagingState.Loading) return
 
-        _isLoading.value = true
+        val isInitial = _videoResults.value.isEmpty()
+        if (isInitial) {
+            _isLoading.value = true
+        } else {
+            _pagingState.value = PagingState.Loading
+        }
+
         viewModelScope.launch {
             when (val result = searchVideosUseCase(currentKeyword, videoCursor)) {
                 is Resource.Success -> {
                     val (newVideos, nextCursor) = result.data
-                    _videoResults.value = _videoResults.value + newVideos
-                    if (nextCursor == -1L) {
+                    val currentVideos = _videoResults.value.toMutableList()
+                    val existingIds = currentVideos.map { it.id }.toSet()
+                    val uniqueNewVideos = newVideos.filter { it.id !in existingIds }
+
+                    _videoResults.value = currentVideos + uniqueNewVideos
+
+                    if (nextCursor == -1L || nextCursor == videoCursor) {
                         hasMoreVideos = false
                     } else {
                         videoCursor = nextCursor
+                        hasMoreVideos = true
                     }
+
                     if (_videoResults.value.isEmpty()) {
                         _uiState.value = SearchUiState.Empty
+                    } else {
+                        _uiState.value = SearchUiState.Results
                     }
+                    _pagingState.value = PagingState.Idle
                 }
                 is Resource.Error -> {
-                    if (_videoResults.value.isEmpty()) {
+                    if (isInitial) {
                         _uiState.value = SearchUiState.Error(result.message)
+                    } else {
+                        _pagingState.value = PagingState.Error(result.message)
                     }
                 }
-                else -> {}
+                else -> {
+                    _pagingState.value = PagingState.Idle
+                }
             }
             _isLoading.value = false
         }
     }
 
     private fun loadMoreUsers() {
-        if (!hasMoreUsers || _isLoading.value) return
+        if (!hasMoreUsers || _isLoading.value || _pagingState.value is PagingState.Loading) return
 
-        _isLoading.value = true
+        val isInitial = _userResults.value.isEmpty()
+        if (isInitial) {
+            _isLoading.value = true
+        } else {
+            _pagingState.value = PagingState.Loading
+        }
+
         viewModelScope.launch {
             when (val result = searchUsersUseCase(currentKeyword, userCursor)) {
                 is Resource.Success -> {
                     val (newUsers, nextCursor) = result.data
-                    _userResults.value = _userResults.value + newUsers
-                    if (nextCursor == -1L) {
+                    val currentUsers = _userResults.value.toMutableList()
+                    val existingIds = currentUsers.map { it.id }.toSet()
+                    val uniqueNewUsers = newUsers.filter { it.id !in existingIds }
+
+                    _userResults.value = currentUsers + uniqueNewUsers
+
+                    if (nextCursor == -1L || nextCursor == userCursor) {
                         hasMoreUsers = false
                     } else {
                         userCursor = nextCursor
+                        hasMoreUsers = true
                     }
-                    if (_userResults.value.isEmpty() && _videoResults.value.isEmpty()) {
-                         // Only set Empty if both are empty?
-                         // No, if the current tab is empty, we might want to show empty.
-                         // But usually we stay in Results state and show an empty list.
-                    }
+                    _pagingState.value = PagingState.Idle
                 }
                 is Resource.Error -> {
-                    // Handle error
+                    if (!isInitial) {
+                        _pagingState.value = PagingState.Error(result.message)
+                    }
                 }
-                else -> {}
+                else -> {
+                    _pagingState.value = PagingState.Idle
+                }
             }
             _isLoading.value = false
         }

--- a/DouyinLite/feature_home/src/test/java/com/app/douyin/pro/feature/home/viewmodel/SearchViewModelTest.kt
+++ b/DouyinLite/feature_home/src/test/java/com/app/douyin/pro/feature/home/viewmodel/SearchViewModelTest.kt
@@ -1,0 +1,140 @@
+package com.app.douyin.pro.feature.home.viewmodel
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.app.douyin.pro.feature.home.data.SearchRepository
+import com.app.douyin.pro.feature.home.domain.usecase.SearchUsersUseCase
+import com.app.douyin.pro.feature.home.domain.usecase.SearchVideosUseCase
+import com.app.douyin.pro.lib.media.interaction.VideoInteractionManager
+import com.app.douyin.pro.lib.media.model.Resource
+import com.app.douyin.pro.lib.media.model.UserModel
+import com.app.douyin.pro.lib.media.model.VideoModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.*
+
+import kotlinx.coroutines.runBlocking
+
+@ExperimentalCoroutinesApi
+class SearchViewModelTest {
+
+    private lateinit var viewModel: SearchViewModel
+    private val searchVideosUseCase: SearchVideosUseCase = mock(SearchVideosUseCase::class.java)
+    private val searchUsersUseCase: SearchUsersUseCase = mock(SearchUsersUseCase::class.java)
+    private val searchRepository: SearchRepository = mock(SearchRepository::class.java)
+    private val interactionManager: VideoInteractionManager = mock(VideoInteractionManager::class.java)
+    private val context: Context = mock(Context::class.java)
+    private val sharedPrefs: SharedPreferences = mock(SharedPreferences::class.java)
+    private val editor: SharedPreferences.Editor = mock(SharedPreferences.Editor::class.java)
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        `when`(context.getSharedPreferences(anyString(), anyInt())).thenReturn(sharedPrefs)
+        `when`(sharedPrefs.edit()).thenReturn(editor)
+        `when`(editor.putString(anyString(), anyString())).thenReturn(editor)
+        `when`(editor.remove(anyString())).thenReturn(editor)
+        `when`(editor.apply()).then { }
+        `when`(interactionManager.interactionEvents).thenReturn(MutableSharedFlow())
+        runBlocking {
+            `when`(searchRepository.getHotWords()).thenReturn(Resource.Success(emptyList()))
+        }
+        `when`(sharedPrefs.getString(anyString(), anyString())).thenReturn("")
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `search success updates videoResults and userResults`() = runTest {
+        val keyword = "test"
+        val user = UserModel(101, "a1", "av1")
+        val videos = listOf(VideoModel(1, user, "p1", "c1", "t1"))
+        `when`(searchVideosUseCase.invoke(anyString(), anyLong())).thenReturn(Resource.Success(Pair(videos, 1L)))
+
+        viewModel = SearchViewModel(searchVideosUseCase, searchUsersUseCase, searchRepository, interactionManager, context)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.search(keyword)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(SearchUiState.Results, viewModel.uiState.value)
+        assertEquals(videos, viewModel.videoResults.value)
+    }
+
+    @Test
+    fun `loadMore appends and deduplicates videos`() = runTest {
+        val keyword = "test"
+        val user1 = UserModel(101, "a1", "av1")
+        val user2 = UserModel(102, "a2", "av2")
+        val video1 = VideoModel(1, user1, "p1", "c1", "t1")
+        val video2 = VideoModel(2, user2, "p2", "c2", "t2")
+
+        `when`(searchVideosUseCase.invoke(anyString(), eq(0L))).thenReturn(Resource.Success(Pair(listOf(video1), 1L)))
+        `when`(searchVideosUseCase.invoke(anyString(), eq(1L))).thenReturn(Resource.Success(Pair(listOf(video1, video2), 2L)))
+
+        viewModel = SearchViewModel(searchVideosUseCase, searchUsersUseCase, searchRepository, interactionManager, context)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.search(keyword)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, viewModel.videoResults.value.size)
+
+        viewModel.loadMore()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(2, viewModel.videoResults.value.size)
+        assertEquals(listOf(video1, video2), viewModel.videoResults.value)
+        assertEquals(PagingState.Idle, viewModel.pagingState.value)
+    }
+
+    @Test
+    fun `search with no results updates state to Empty`() = runTest {
+        val keyword = "nothing"
+        `when`(searchVideosUseCase.invoke(anyString(), anyLong())).thenReturn(Resource.Success(Pair(emptyList(), -1L)))
+
+        viewModel = SearchViewModel(searchVideosUseCase, searchUsersUseCase, searchRepository, interactionManager, context)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.search(keyword)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(SearchUiState.Empty, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `loadMore fails updates pagingState to Error`() = runTest {
+        val keyword = "test"
+        val user1 = UserModel(101, "a1", "av1")
+        val video1 = VideoModel(1, user1, "p1", "c1", "t1")
+        val errorMessage = "Network Fail"
+
+        `when`(searchVideosUseCase.invoke(anyString(), eq(0L))).thenReturn(Resource.Success(Pair(listOf(video1), 1L)))
+        `when`(searchVideosUseCase.invoke(anyString(), eq(1L))).thenReturn(Resource.Error(errorMessage))
+
+        viewModel = SearchViewModel(searchVideosUseCase, searchUsersUseCase, searchRepository, interactionManager, context)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.search(keyword)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.loadMore()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1, viewModel.videoResults.value.size)
+        assertTrue(viewModel.pagingState.value is PagingState.Error)
+        assertEquals(errorMessage, (viewModel.pagingState.value as PagingState.Error).message)
+    }
+}


### PR DESCRIPTION
This PR stabilizes the video search result experience by implementing robust pagination, clear state management, and a seamless playback flow. 

Key changes include:
1. **Shared State**: PagingState is now in a common file to avoid duplication.
2. **Stable Pagination**: SearchViewModel now handles cursors and deduplication correctly, following the project's paging checklist.
3. **UI Feedback**: Search results now show loading/retry states at the end of the list.
4. **Playback Path**: Users can now click search results to enter a full-screen video feed starting at the selected item. The search state (keyword, results, scroll position) is preserved when returning.
5. **Testing**: New unit tests verify the search and pagination logic in SearchViewModel.

Fixes #79

---
*PR created automatically by Jules for task [6393313342830559794](https://jules.google.com/task/6393313342830559794) started by @zx2121651*