### PR TITLE
Establish user search results and profile status synchronization

### DIFF
--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/AppNavigation.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/AppNavigation.kt
@@ -99,6 +99,15 @@ fun AppNavHost(
                 onNavigateToLogin = { navController.navigate(NavRoutes.LOGIN) }
             )
         }
+        composable(
+            route = NavRoutes.USER_PROFILE,
+            arguments = listOf(navArgument("userId") { type = NavType.LongType })
+        ) {
+            ProfileScreen(
+                onNavigateToLogin = { navController.navigate(NavRoutes.LOGIN) },
+                onBack = { navController.popBackStack() }
+            )
+        }
         composable(NavRoutes.MALL) {
             MallScreen(onBack = { navController.popBackStack() })
         }
@@ -107,6 +116,9 @@ fun AppNavHost(
                 onBack = { navController.popBackStack() },
                 onVideoClick = { keyword, index ->
                     navController.navigate(NavRoutes.buildSearchPlayerRoute(keyword, index))
+                },
+                onUserClick = { userId ->
+                    navController.navigate(NavRoutes.buildUserProfileRoute(userId))
                 }
             )
         }

--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/NavRoutes.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/NavRoutes.kt
@@ -30,6 +30,11 @@ object NavRoutes {
         return "search_player?keyword=${android.net.Uri.encode(keyword)}&index=$index"
     }
 
+    const val USER_PROFILE = "profile/{userId}"
+    fun buildUserProfileRoute(userId: Long): String {
+        return "profile/$userId"
+    }
+
     const val LOGIN = "login"
     const val REGISTER = "register"
 }

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/SearchScreen.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/ui/SearchScreen.kt
@@ -45,6 +45,7 @@ import com.app.douyin.pro.lib.media.util.CountFormatter
 fun SearchScreen(
     onBack: () -> Unit,
     onVideoClick: (String, Int) -> Unit = { _, _ -> },
+    onUserClick: (Long) -> Unit = {},
     viewModel: SearchViewModel = hiltViewModel()
 ) {
     var searchQuery by remember { mutableStateOf("") }
@@ -96,7 +97,8 @@ fun SearchScreen(
                         onLoadMore = { viewModel.loadMore() },
                         onLikeClick = { viewModel.toggleLike(it) },
                         onFollowClick = { viewModel.toggleFollow(it) },
-                        onVideoClick = { index -> onVideoClick(searchQuery, index) }
+                        onVideoClick = { index -> onVideoClick(searchQuery, index) },
+                        onUserClick = onUserClick
                     )
                 }
                 is SearchUiState.Empty -> {
@@ -364,7 +366,8 @@ fun SearchResultContent(
     onLoadMore: () -> Unit,
     onLikeClick: (Long) -> Unit,
     onFollowClick: (Long) -> Unit,
-    onVideoClick: (Int) -> Unit
+    onVideoClick: (Int) -> Unit,
+    onUserClick: (Long) -> Unit
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         TabRow(
@@ -393,22 +396,31 @@ fun SearchResultContent(
 
         Box(modifier = Modifier.weight(1f)) {
             if (selectedTab == SearchResultType.Video) {
-                VideoResultList(
-                    videos = videoResults,
-                    isLoading = isLoading,
-                    pagingState = pagingState,
-                    onLoadMore = onLoadMore,
-                    onLikeClick = onLikeClick,
-                    onVideoClick = onVideoClick
-                )
+                if (!isLoading && videoResults.isEmpty()) {
+                    EmptySearchView(onRetry = onLoadMore)
+                } else {
+                    VideoResultList(
+                        videos = videoResults,
+                        isLoading = isLoading,
+                        pagingState = pagingState,
+                        onLoadMore = onLoadMore,
+                        onLikeClick = onLikeClick,
+                        onVideoClick = onVideoClick
+                    )
+                }
             } else {
-                UserResultList(
-                    users = userResults,
-                    isLoading = isLoading,
-                    pagingState = pagingState,
-                    onLoadMore = onLoadMore,
-                    onFollowClick = onFollowClick
-                )
+                if (!isLoading && userResults.isEmpty()) {
+                    EmptySearchView(onRetry = onLoadMore)
+                } else {
+                    UserResultList(
+                        users = userResults,
+                        isLoading = isLoading,
+                        pagingState = pagingState,
+                        onLoadMore = onLoadMore,
+                        onFollowClick = onFollowClick,
+                        onUserClick = onUserClick
+                    )
+                }
             }
         }
     }
@@ -516,7 +528,8 @@ fun UserResultList(
     isLoading: Boolean,
     pagingState: com.app.douyin.pro.feature.home.viewmodel.PagingState,
     onLoadMore: () -> Unit,
-    onFollowClick: (Long) -> Unit
+    onFollowClick: (Long) -> Unit,
+    onUserClick: (Long) -> Unit
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -524,7 +537,7 @@ fun UserResultList(
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         items(users) { user ->
-            UserResultItem(user = user, onFollowClick = onFollowClick)
+            UserResultItem(user = user, onFollowClick = onFollowClick, onUserClick = onUserClick)
         }
         item {
             if (isLoading || pagingState is com.app.douyin.pro.feature.home.viewmodel.PagingState.Loading) {
@@ -548,9 +561,11 @@ fun UserResultList(
 }
 
 @Composable
-fun UserResultItem(user: UserModel, onFollowClick: (Long) -> Unit) {
+fun UserResultItem(user: UserModel, onFollowClick: (Long) -> Unit, onUserClick: (Long) -> Unit) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onUserClick(user.id) },
         verticalAlignment = Alignment.CenterVertically
     ) {
         AsyncImage(

--- a/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/SearchViewModel.kt
+++ b/DouyinLite/feature_home/src/main/java/com/app/douyin/pro/feature/home/viewmodel/SearchViewModel.kt
@@ -168,25 +168,34 @@ class SearchViewModel @Inject constructor(
                         }
                     }
                     is InteractionEvent.FollowChanged -> {
-                        var changed = false
+                        var videoChanged = false
                         currentVideos.forEachIndexed { index, video ->
                             if (video.author.id == event.authorId) {
                                 currentVideos[index] = video.copy(author = video.author.copy(isFollowed = event.isFollowed))
-                                changed = true
+                                videoChanged = true
                             }
                         }
-                        if (changed) {
+                        if (videoChanged) {
                             _videoResults.value = currentVideos
                         }
 
+                        var userChanged = false
                         val currentUsers = _userResults.value.toMutableList()
                         currentUsers.forEachIndexed { index, user ->
                             if (user.id == event.authorId) {
-                                currentUsers[index] = user.copy(isFollowed = event.isFollowed)
-                                changed = true
+                                val newFollowerCount = if (event.isFollowed) {
+                                    user.followerCount + 1
+                                } else {
+                                    (user.followerCount - 1).coerceAtLeast(0)
+                                }
+                                currentUsers[index] = user.copy(
+                                    isFollowed = event.isFollowed,
+                                    followerCount = newFollowerCount
+                                )
+                                userChanged = true
                             }
                         }
-                        if (changed) {
+                        if (userChanged) {
                             _userResults.value = currentUsers
                         }
                     }
@@ -288,11 +297,7 @@ class SearchViewModel @Inject constructor(
                         hasMoreVideos = true
                     }
 
-                    if (_videoResults.value.isEmpty()) {
-                        _uiState.value = SearchUiState.Empty
-                    } else {
-                        _uiState.value = SearchUiState.Results
-                    }
+                    _uiState.value = SearchUiState.Results
                     _pagingState.value = PagingState.Idle
                 }
                 is Resource.Error -> {
@@ -336,6 +341,8 @@ class SearchViewModel @Inject constructor(
                         userCursor = nextCursor
                         hasMoreUsers = true
                     }
+
+                    _uiState.value = SearchUiState.Results
                     _pagingState.value = PagingState.Idle
                 }
                 is Resource.Error -> {

--- a/DouyinLite/feature_home/src/test/java/com/app/douyin/pro/feature/home/viewmodel/SearchViewModelTest.kt
+++ b/DouyinLite/feature_home/src/test/java/com/app/douyin/pro/feature/home/viewmodel/SearchViewModelTest.kt
@@ -101,7 +101,7 @@ class SearchViewModelTest {
     }
 
     @Test
-    fun `search with no results updates state to Empty`() = runTest {
+    fun `search with no results keep state as Results`() = runTest {
         val keyword = "nothing"
         `when`(searchVideosUseCase.invoke(anyString(), anyLong())).thenReturn(Resource.Success(Pair(emptyList(), -1L)))
 
@@ -111,7 +111,7 @@ class SearchViewModelTest {
         viewModel.search(keyword)
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(SearchUiState.Empty, viewModel.uiState.value)
+        assertEquals(SearchUiState.Results, viewModel.uiState.value)
     }
 
     @Test

--- a/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/data/ProfileRepository.kt
+++ b/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/data/ProfileRepository.kt
@@ -12,14 +12,14 @@ import javax.inject.Singleton
 class ProfileRepository @Inject constructor(
     private val dataSource: ProfileDataSource
 ) {
-    suspend fun getProfileInfo(): Resource<ProfileInfo> = try {
-        Resource.Success(dataSource.getUserInfo())
+    suspend fun getProfileInfo(userId: Long? = null): Resource<ProfileInfo> = try {
+        Resource.Success(dataSource.getUserInfo(userId))
     } catch (e: Exception) {
         Resource.Error(e.message ?: "Unknown Error", AppError.NetworkError)
     }
 
-    suspend fun getPublishedVideos(): Resource<List<VideoModel>> = try {
-        Resource.Success(dataSource.getPublishedVideos())
+    suspend fun getPublishedVideos(userId: Long? = null): Resource<List<VideoModel>> = try {
+        Resource.Success(dataSource.getPublishedVideos(userId))
     } catch (e: Exception) {
         Resource.Error(e.message ?: "Unknown Error", AppError.NetworkError)
     }

--- a/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/data/source/ProfileDataSource.kt
+++ b/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/data/source/ProfileDataSource.kt
@@ -4,30 +4,34 @@ import com.app.douyin.pro.lib.media.network.DouyinApiService
 import com.app.douyin.pro.lib.media.model.VideoModel
 import com.app.douyin.pro.lib.media.model.UserModel
 import com.app.douyin.pro.lib.media.auth.AuthManager
+import com.app.douyin.pro.lib.media.util.CountFormatter
 import javax.inject.Inject
 
 interface ProfileDataSource {
-    suspend fun getUserInfo(): ProfileInfo
-    suspend fun getPublishedVideos(): List<VideoModel>
+    suspend fun getUserInfo(userId: Long?): ProfileInfo
+    suspend fun getPublishedVideos(userId: Long?): List<VideoModel>
 }
 
 class RemoteProfileDataSource @Inject constructor(
     private val apiService: DouyinApiService,
     private val authManager: AuthManager
 ) : ProfileDataSource {
-    override suspend fun getUserInfo(): ProfileInfo {
+    override suspend fun getUserInfo(userId: Long?): ProfileInfo {
         val token = authManager.requireToken()
-        val userId = authManager.getUserId()
+        val targetUserId = userId ?: authManager.getUserId()
 
-        val response = apiService.getUserInfo(userId, token)
+        val response = apiService.getUserInfo(targetUserId, token)
         val user = response.user
 
         if (response.statusCode == 0 && user != null) {
             return ProfileInfo(
-                username = user.name.takeIf { it.isNotEmpty() } ?: "User_$userId",
-                douyinId = "dy_$userId",
+                id = user.id,
+                username = user.name.takeIf { it.isNotEmpty() } ?: "User_$targetUserId",
+                douyinId = "dy_${user.id}",
                 following = user.followCount.toInt(),
-                followers = formatCount(user.followerCount),
+                followers = CountFormatter.format(user.followerCount),
+                followerCount = user.followerCount,
+                isFollowed = user.isFollow,
                 likes = "0", // Currently we don't return total likes received, default to 0
                 avatar = user.avatar,
                 backgroundImage = user.backgroundImage,
@@ -37,13 +41,13 @@ class RemoteProfileDataSource @Inject constructor(
         throw Exception(response.statusMsg ?: "Failed to load profile")
     }
 
-    override suspend fun getPublishedVideos(): List<VideoModel> {
+    override suspend fun getPublishedVideos(userId: Long?): List<VideoModel> {
         if (!authManager.isLoggedIn()) return emptyList()
-        val userId = authManager.getUserId()
+        val targetUserId = userId ?: authManager.getUserId()
         val token = authManager.requireToken()
 
         try {
-            val response = apiService.getPublishList(userId, token)
+            val response = apiService.getPublishList(targetUserId, token)
             if (response.statusCode == 0) {
                 return response.videoList?.map { dto ->
                     VideoModel(
@@ -75,20 +79,16 @@ class RemoteProfileDataSource @Inject constructor(
         return emptyList()
     }
 
-    private fun formatCount(count: Long): String {
-        return if (count >= 10000) {
-            String.format("%.1fw", count / 10000.0)
-        } else {
-            count.toString()
-        }
-    }
 }
 
 data class ProfileInfo(
+    val id: Long,
     val username: String,
     val douyinId: String,
     val following: Int,
     val followers: String,
+    val followerCount: Long,
+    val isFollowed: Boolean,
     val likes: String,
     val avatar: String? = null,
     val backgroundImage: String? = null,

--- a/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/domain/usecase/GetProfileInfoUseCase.kt
+++ b/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/domain/usecase/GetProfileInfoUseCase.kt
@@ -8,5 +8,5 @@ import javax.inject.Inject
 class GetProfileInfoUseCase @Inject constructor(
     private val repository: ProfileRepository
 ) {
-    suspend operator fun invoke(): Resource<ProfileInfo> = repository.getProfileInfo()
+    suspend operator fun invoke(userId: Long? = null): Resource<ProfileInfo> = repository.getProfileInfo(userId)
 }

--- a/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/domain/usecase/GetPublishedVideosUseCase.kt
+++ b/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/domain/usecase/GetPublishedVideosUseCase.kt
@@ -8,5 +8,5 @@ import javax.inject.Inject
 class GetPublishedVideosUseCase @Inject constructor(
     private val repository: ProfileRepository
 ) {
-    suspend operator fun invoke(): Resource<List<VideoModel>> = repository.getPublishedVideos()
+    suspend operator fun invoke(userId: Long? = null): Resource<List<VideoModel>> = repository.getPublishedVideos(userId)
 }

--- a/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/ui/ProfileScreen.kt
+++ b/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/ui/ProfileScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
@@ -45,6 +46,7 @@ import kotlin.math.roundToInt
 @Composable
 fun ProfileScreen(
     onNavigateToLogin: () -> Unit,
+    onBack: (() -> Unit)? = null,
     viewModel: ProfileViewModel = hiltViewModel()
 ) {
     val sessionState by viewModel.sessionState.collectAsState()
@@ -213,23 +215,52 @@ fun ProfileScreen(
 
                 // Action Buttons
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Button(
-                        onClick = { viewModel.logout() },
-                        modifier = Modifier.weight(1f).height(40.dp),
-                        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2E2E2E)),
-                        shape = RoundedCornerShape(8.dp),
-                        contentPadding = PaddingValues(0.dp)
-                    ) {
-                        Text("退出登录", fontSize = 14.sp, fontWeight = FontWeight.Bold)
-                    }
-                    Button(
-                        onClick = {},
-                        modifier = Modifier.weight(1f).height(40.dp),
-                        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2E2E2E)),
-                        shape = RoundedCornerShape(8.dp),
-                        contentPadding = PaddingValues(0.dp)
-                    ) {
-                        Text("编辑资料", fontSize = 14.sp, fontWeight = FontWeight.Bold)
+                    if (viewModel.isSelf()) {
+                        Button(
+                            onClick = { viewModel.logout() },
+                            modifier = Modifier.weight(1f).height(40.dp),
+                            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2E2E2E)),
+                            shape = RoundedCornerShape(8.dp),
+                            contentPadding = PaddingValues(0.dp)
+                        ) {
+                            Text("退出登录", fontSize = 14.sp, fontWeight = FontWeight.Bold)
+                        }
+                        Button(
+                            onClick = {},
+                            modifier = Modifier.weight(1f).height(40.dp),
+                            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2E2E2E)),
+                            shape = RoundedCornerShape(8.dp),
+                            contentPadding = PaddingValues(0.dp)
+                        ) {
+                            Text("编辑资料", fontSize = 14.sp, fontWeight = FontWeight.Bold)
+                        }
+                    } else {
+                        val isFollowed = profileInfo?.isFollowed ?: false
+                        Button(
+                            onClick = { viewModel.toggleFollow() },
+                            modifier = Modifier.weight(1f).height(40.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = if (isFollowed) Color(0xFF2E2E2E) else Color(0xFFFE2C55)
+                            ),
+                            shape = RoundedCornerShape(8.dp),
+                            contentPadding = PaddingValues(0.dp)
+                        ) {
+                            Text(
+                                if (isFollowed) "已关注" else "关注",
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = Color.White
+                            )
+                        }
+                        Button(
+                            onClick = {},
+                            modifier = Modifier.weight(1f).height(40.dp),
+                            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2E2E2E)),
+                            shape = RoundedCornerShape(8.dp),
+                            contentPadding = PaddingValues(0.dp)
+                        ) {
+                            Text("私信", fontSize = 14.sp, fontWeight = FontWeight.Bold, color = Color.White)
+                        }
                     }
                     Box(
                         modifier = Modifier
@@ -355,7 +386,16 @@ fun ProfileScreen(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Icon(Icons.Filled.Add, contentDescription = null, tint = Color.White)
+            if (viewModel.isSelf()) {
+                Icon(Icons.Filled.Add, contentDescription = null, tint = Color.White)
+            } else {
+                Icon(
+                    Icons.Filled.ArrowBack,
+                    contentDescription = "Back",
+                    tint = Color.White,
+                    modifier = Modifier.clickable { onBack?.invoke() }
+                )
+            }
 
             // Name fades in when toolbar collapses
             Text(

--- a/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/viewmodel/ProfileViewModel.kt
+++ b/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/viewmodel/ProfileViewModel.kt
@@ -1,5 +1,6 @@
 package com.app.douyin.pro.feature.profile.viewmodel
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.app.douyin.pro.feature.profile.data.source.ProfileInfo
@@ -7,9 +8,13 @@ import com.app.douyin.pro.feature.profile.domain.usecase.GetProfileInfoUseCase
 import com.app.douyin.pro.lib.media.model.Resource
 
 import com.app.douyin.pro.feature.profile.domain.usecase.GetPublishedVideosUseCase
+import com.app.douyin.pro.lib.media.auth.AuthManager
 import com.app.douyin.pro.lib.media.auth.AuthRepository
 import com.app.douyin.pro.lib.media.auth.SessionState
+import com.app.douyin.pro.lib.media.interaction.InteractionEvent
+import com.app.douyin.pro.lib.media.interaction.VideoInteractionManager
 import com.app.douyin.pro.lib.media.model.VideoModel
+import com.app.douyin.pro.lib.media.util.CountFormatter
 
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,8 +27,13 @@ import javax.inject.Inject
 class ProfileViewModel @Inject constructor(
     private val getProfileInfoUseCase: GetProfileInfoUseCase,
     private val getPublishedVideosUseCase: GetPublishedVideosUseCase,
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val authManager: AuthManager,
+    private val interactionManager: VideoInteractionManager,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+    val userId: Long? = savedStateHandle.get<Long>("userId")?.takeIf { it > 0 }
+
     val sessionState: StateFlow<SessionState> = authRepository.getSessionState()
 
     private val _profileInfo = MutableStateFlow<ProfileInfo?>(null)
@@ -40,9 +50,37 @@ class ProfileViewModel @Inject constructor(
             sessionState.collect { state ->
                 if (state is SessionState.LoggedIn) {
                     loadProfile()
+                } else if (userId != null) {
+                    // Even if not logged in, we might be able to see some profiles if backend allows
+                    // But usually, we follow the current session logic.
+                    // For now, if there's a specific userId, we try to load it.
+                    loadProfile()
                 } else {
                     _profileInfo.value = null
                     _publishedVideos.value = emptyList()
+                }
+            }
+        }
+        observeInteractions()
+    }
+
+    private fun observeInteractions() {
+        viewModelScope.launch {
+            interactionManager.interactionEvents.collect { event ->
+                if (event is InteractionEvent.FollowChanged) {
+                    val currentInfo = _profileInfo.value
+                    if (currentInfo != null && currentInfo.id == event.authorId) {
+                        val newFollowerCount = if (event.isFollowed) {
+                            currentInfo.followerCount + 1
+                        } else {
+                            (currentInfo.followerCount - 1).coerceAtLeast(0)
+                        }
+                        _profileInfo.value = currentInfo.copy(
+                            isFollowed = event.isFollowed,
+                            followerCount = newFollowerCount,
+                            followers = CountFormatter.format(newFollowerCount)
+                        )
+                    }
                 }
             }
         }
@@ -51,16 +89,25 @@ class ProfileViewModel @Inject constructor(
     fun loadProfile() {
         viewModelScope.launch {
             _isLoading.value = true
-            when (val result = getProfileInfoUseCase()) {
+            when (val result = getProfileInfoUseCase(userId)) {
                 is Resource.Success -> _profileInfo.value = result.data
                 else -> _profileInfo.value = null
             }
-            when (val result = getPublishedVideosUseCase()) {
+            when (val result = getPublishedVideosUseCase(userId)) {
                 is Resource.Success -> _publishedVideos.value = result.data
                 else -> _publishedVideos.value = emptyList()
             }
             _isLoading.value = false
         }
+    }
+
+    fun toggleFollow() {
+        val info = _profileInfo.value ?: return
+        interactionManager.toggleFollow(info.id, info.isFollowed)
+    }
+
+    fun isSelf(): Boolean {
+        return userId == null || userId == authManager.getUserId()
     }
 
     fun logout() {


### PR DESCRIPTION
This change integrates user search results with user profiles and synchronizes follow status across the application.

Key changes:
- Enhanced `ProfileInfo` data model to include relationship status and follower counts.
- Updated `ProfileDataSource`, `ProfileRepository`, and use cases to support fetching profiles for arbitrary user IDs.
- Updated `ProfileViewModel` to handle both the current user and other users, utilizing `SavedStateHandle` for navigation arguments.
- Implemented global follow status synchronization by observing `VideoInteractionManager` events in both `SearchViewModel` and `ProfileViewModel`.
- Added navigation from user search results to the profile page.
- Updated `ProfileScreen` UI to show appropriate action buttons (Follow/Message vs Edit/Logout) based on whether the profile belongs to the current user.
- Fixed `SearchViewModel` to allow tab switching when one tab is empty and improved empty state hints in `SearchScreen`.
- Synchronized `followerCount` updates in search results when follow status changes.
- Eliminated code duplication by using a centralized `CountFormatter` for user follower counts.

Fixes #80

---
*PR created automatically by Jules for task [13583806117421391590](https://jules.google.com/task/13583806117421391590) started by @zx2121651*