### PR TITLE
Refactor Message Page to Unified Conversation State Model

### DIFF
--- a/DouyinLite/feature_inbox/build.gradle.kts
+++ b/DouyinLite/feature_inbox/build.gradle.kts
@@ -55,5 +55,6 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation("androidx.compose.material:material:1.6.7")
     implementation(libs.androidx.compose.material.icons.extended)
 }

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/data/InboxRepository.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/data/InboxRepository.kt
@@ -1,6 +1,8 @@
 package com.app.douyin.pro.feature.inbox.data
 
 import com.app.douyin.pro.feature.inbox.data.source.InboxDataSource
+import com.app.douyin.pro.feature.inbox.domain.model.Conversation
+import com.app.douyin.pro.feature.inbox.domain.model.NotificationCategory
 import com.app.douyin.pro.lib.media.model.Resource
 import com.app.douyin.pro.lib.media.model.AppError
 import javax.inject.Inject
@@ -10,10 +12,10 @@ import javax.inject.Singleton
 class InboxRepository @Inject constructor(
     private val dataSource: InboxDataSource
 ) {
-    suspend fun getMessages(): Resource<List<com.app.douyin.pro.feature.inbox.domain.model.Message>> = try {
+    suspend fun getMessages(): Resource<List<Conversation>> = try {
         Resource.Success(dataSource.getMessages())
     } catch (e: Exception) {
         Resource.Error(e.message ?: "Unknown Error", AppError.NetworkError)
     }
-    suspend fun getCategories(): Resource<List<com.app.douyin.pro.feature.inbox.domain.model.NotificationCategory>> = Resource.Success(dataSource.getCategories())
+    suspend fun getCategories(): Resource<List<NotificationCategory>> = Resource.Success(dataSource.getCategories())
 }

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/data/source/InboxDataSource.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/data/source/InboxDataSource.kt
@@ -1,6 +1,6 @@
 package com.app.douyin.pro.feature.inbox.data.source
 
-import com.app.douyin.pro.feature.inbox.domain.model.Message
+import com.app.douyin.pro.feature.inbox.domain.model.Conversation
 import com.app.douyin.pro.feature.inbox.domain.model.NotificationCategory
 import com.app.douyin.pro.lib.media.network.DouyinApiService
 import com.app.douyin.pro.lib.media.auth.AuthManager
@@ -10,7 +10,7 @@ import java.util.Date
 import java.util.Locale
 
 interface InboxDataSource {
-    suspend fun getMessages(): List<Message>
+    suspend fun getMessages(): List<Conversation>
     suspend fun getCategories(): List<NotificationCategory>
 }
 
@@ -19,7 +19,7 @@ class RemoteInboxDataSource @Inject constructor(
     private val authManager: AuthManager
 ) : InboxDataSource {
 
-    override suspend fun getMessages(): List<Message> {
+    override suspend fun getMessages(): List<Conversation> {
         try {
             if (!authManager.isLoggedIn()) return emptyList()
             val token = authManager.requireToken()
@@ -29,14 +29,15 @@ class RemoteInboxDataSource @Inject constructor(
                 val list = response.notificationList
                 if (list != null) {
                     return list.map { dto ->
-                        Message(
+                        Conversation(
                             id = dto.id.toString(),
                             avatarUrl = dto.fromUser?.avatar ?: "https://api.dicebear.com/7.x/avataaars/png?seed=${dto.id}",
                             name = dto.fromUser?.name ?: "系统通知",
-                            time = format.format(Date(dto.createTime)),
-                            content = dto.content,
+                            lastTime = format.format(Date(dto.createTime)),
+                            lastTimestamp = dto.createTime,
+                            lastMessage = dto.content,
                             isOfficial = dto.type == "system",
-                            hasUnreadDot = !dto.isRead,
+                            unreadCount = if (dto.isRead) 0 else 1,
                             isLive = false
                         )
                     }

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/domain/model/InboxModels.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/domain/model/InboxModels.kt
@@ -1,13 +1,14 @@
 package com.app.douyin.pro.feature.inbox.domain.model
 
-data class Message(
+data class Conversation(
     val id: String,
     val avatarUrl: String,
     val name: String,
-    val time: String,
-    val content: String,
+    val lastTime: String,
+    val lastTimestamp: Long,
+    val lastMessage: String,
     val isOfficial: Boolean = false,
-    val hasUnreadDot: Boolean = false,
+    val unreadCount: Int = 0,
     val isLive: Boolean = false
 )
 

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/domain/usecase/GetMessagesUseCase.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/domain/usecase/GetMessagesUseCase.kt
@@ -1,12 +1,12 @@
 package com.app.douyin.pro.feature.inbox.domain.usecase
 
 import com.app.douyin.pro.feature.inbox.data.InboxRepository
-import com.app.douyin.pro.feature.inbox.domain.model.Message
+import com.app.douyin.pro.feature.inbox.domain.model.Conversation
 import com.app.douyin.pro.lib.media.model.Resource
 import javax.inject.Inject
 
 class GetMessagesUseCase @Inject constructor(
     private val repository: InboxRepository
 ) {
-    suspend operator fun invoke(): Resource<List<Message>> = repository.getMessages()
+    suspend operator fun invoke(): Resource<List<Conversation>> = repository.getMessages()
 }

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/InboxScreen.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/InboxScreen.kt
@@ -7,8 +7,12 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -22,8 +26,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
-import com.app.douyin.pro.feature.inbox.domain.model.Message
+import com.app.douyin.pro.feature.inbox.domain.model.Conversation
 import com.app.douyin.pro.feature.inbox.domain.model.NotificationCategory
+import com.app.douyin.pro.feature.inbox.ui.vm.InboxUiState
 import com.app.douyin.pro.feature.inbox.ui.vm.InboxViewModel
 
 val DarkSurface = Color(0xFF161823)
@@ -32,13 +37,21 @@ val TextPrimary = Color(0xFFE1E1F1)
 val TextSecondary = Color(0xFF909191)
 val ErrorColorDot = Color(0xFFFF0050)
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Composable
-fun InboxScreen(onNavigateToChat: (Long, String) -> Unit = { _, _ -> },
+fun InboxScreen(
+    onNavigateToChat: (Long, String) -> Unit = { _, _ -> },
     viewModel: InboxViewModel = hiltViewModel()
 ) {
-    val messages by viewModel.messages.collectAsState()
-    val categories by viewModel.categories.collectAsState()
+    val uiState by viewModel.uiState.collectAsState()
+
+    // For pull refresh, we only show indicator if we are Success but refreshing
+    // Actually let's use a separate refresh state if we wanted to be perfect,
+    // but we can use the current state.
+    val pullRefreshState = rememberPullRefreshState(
+        refreshing = uiState is InboxUiState.Loading,
+        onRefresh = { viewModel.refresh() }
+    )
 
     Scaffold(
         topBar = {
@@ -58,19 +71,83 @@ fun InboxScreen(onNavigateToChat: (Long, String) -> Unit = { _, _ -> },
         },
         containerColor = DarkSurface
     ) { paddingValues ->
-
-        if (messages.isEmpty() && categories.isEmpty()) {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator(color = Color(0xFFFF0050))
+        Box(modifier = Modifier.fillMaxSize().padding(paddingValues).pullRefresh(pullRefreshState)) {
+            when (val state = uiState) {
+                is InboxUiState.Loading -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator(color = Color(0xFFFF0050))
+                    }
+                }
+                is InboxUiState.Empty -> {
+                    EmptyInboxView { viewModel.refresh() }
+                }
+                is InboxUiState.Error -> {
+                    ErrorInboxView(state.message) { viewModel.refresh() }
+                }
+                is InboxUiState.Success -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(bottom = 80.dp)
+                    ) {
+                        item { NotificationCategoriesRow(state.categories) }
+                        item { Spacer(modifier = Modifier.height(8.dp)) }
+                        items(state.conversations, key = { it.id }) { conversation ->
+                            ConversationItemRow(conversation, onNavigateToChat)
+                        }
+                    }
+                }
             }
+
+            PullRefreshIndicator(
+                refreshing = uiState is InboxUiState.Loading,
+                state = pullRefreshState,
+                modifier = Modifier.align(Alignment.TopCenter),
+                backgroundColor = DarkSurfaceContainer,
+                contentColor = Color(0xFFFF0050)
+            )
         }
-        LazyColumn(
-            modifier = Modifier.fillMaxSize().padding(paddingValues),
-            contentPadding = PaddingValues(bottom = 80.dp)
+    }
+}
+
+@Composable
+fun EmptyInboxView(onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(Icons.Default.MailOutline, contentDescription = null, tint = TextSecondary, modifier = Modifier.size(64.dp))
+        Spacer(modifier = Modifier.height(16.dp))
+        Text("暂无消息", color = TextSecondary, fontSize = 14.sp)
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(
+            onClick = onRetry,
+            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF0050))
         ) {
-            item { NotificationCategoriesRow(categories) }
-            item { Spacer(modifier = Modifier.height(8.dp)) }
-            items(messages) { message -> MessageItemRow(message, onNavigateToChat) }
+            Text("刷新一下")
+        }
+    }
+}
+
+@Composable
+fun ErrorInboxView(message: String, onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(Icons.Default.ErrorOutline, contentDescription = null, tint = Color.Gray, modifier = Modifier.size(64.dp))
+        Spacer(modifier = Modifier.height(16.dp))
+        Text("加载失败", color = TextPrimary, fontSize = 16.sp, fontWeight = FontWeight.Bold)
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(message, color = TextSecondary, fontSize = 13.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
+        Spacer(modifier = Modifier.height(24.dp))
+        OutlinedButton(
+            onClick = onRetry,
+            border = androidx.compose.foundation.BorderStroke(1.dp, Color(0xFFFF0050)),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = Color(0xFFFF0050))
+        ) {
+            Text("重新加载")
         }
     }
 }
@@ -121,19 +198,17 @@ fun CategoryItem(category: NotificationCategory) {
 }
 
 @Composable
-fun MessageItemRow(message: Message, onNavigateToChat: (Long, String) -> Unit) {
+fun ConversationItemRow(conversation: Conversation, onNavigateToChat: (Long, String) -> Unit) {
     Row(
         modifier = Modifier.fillMaxWidth().clickable {
-            // In a real app, message should contain target user ID.
-            // Since we mocked some IDs via seed earlier, let's just extract numeric ID if possible or default to 1
-            val targetId = message.id.toLongOrNull() ?: 1L
-            onNavigateToChat(targetId, message.name)
+            val targetId = conversation.id.toLongOrNull() ?: 1L
+            onNavigateToChat(targetId, conversation.name)
         }.padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Box(modifier = Modifier.size(48.dp)) {
-            AsyncImage(model = message.avatarUrl, contentDescription = null, contentScale = ContentScale.Crop, modifier = Modifier.fillMaxSize().clip(CircleShape).then(if (message.isLive) Modifier.background(Color(0xFFFF5168), CircleShape).padding(2.dp).clip(CircleShape) else Modifier))
-            if (message.isOfficial) {
+            AsyncImage(model = conversation.avatarUrl, contentDescription = null, contentScale = ContentScale.Crop, modifier = Modifier.fillMaxSize().clip(CircleShape).then(if (conversation.isLive) Modifier.background(Color(0xFFFF5168), CircleShape).padding(2.dp).clip(CircleShape) else Modifier))
+            if (conversation.isOfficial) {
                 Box(modifier = Modifier.align(Alignment.BottomEnd).size(14.dp).clip(CircleShape).background(Color(0xFF35FBF5)), contentAlignment = Alignment.Center) {
                     Icon(Icons.Default.Check, null, tint = Color(0xFF00504D), modifier = Modifier.size(10.dp))
                 }
@@ -142,10 +217,31 @@ fun MessageItemRow(message: Message, onNavigateToChat: (Long, String) -> Unit) {
         Spacer(modifier = Modifier.width(16.dp))
         Column(modifier = Modifier.weight(1f)) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                Text(message.name, color = TextPrimary, fontSize = 15.sp, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                Text(message.time, color = TextSecondary, fontSize = 12.sp)
+                Text(conversation.name, color = TextPrimary, fontSize = 15.sp, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(conversation.lastTime, color = TextSecondary, fontSize = 12.sp)
             }
-            Text(message.content, color = TextSecondary, fontSize = 13.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                Text(conversation.lastMessage, color = TextSecondary, fontSize = 13.sp, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
+                if (conversation.unreadCount > 0) {
+                    Box(
+                        modifier = Modifier
+                            .padding(start = 8.dp)
+                            .defaultMinSize(minWidth = 16.dp)
+                            .height(16.dp)
+                            .clip(CircleShape)
+                            .background(ErrorColorDot)
+                            .padding(horizontal = 4.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = if (conversation.unreadCount > 99) "99+" else conversation.unreadCount.toString(),
+                            color = Color.White,
+                            fontSize = 10.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/vm/InboxViewModel.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/vm/InboxViewModel.kt
@@ -2,7 +2,7 @@ package com.app.douyin.pro.feature.inbox.ui.vm
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.app.douyin.pro.feature.inbox.domain.model.Message
+import com.app.douyin.pro.feature.inbox.domain.model.Conversation
 import com.app.douyin.pro.feature.inbox.domain.model.NotificationCategory
 import com.app.douyin.pro.feature.inbox.domain.usecase.GetCategoriesUseCase
 import com.app.douyin.pro.feature.inbox.domain.usecase.GetMessagesUseCase
@@ -11,39 +11,76 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+sealed class InboxUiState {
+    object Loading : InboxUiState()
+    data class Success(
+        val categories: List<NotificationCategory>,
+        val conversations: List<Conversation>
+    ) : InboxUiState()
+    object Empty : InboxUiState()
+    data class Error(val message: String) : InboxUiState()
+}
 
 @HiltViewModel
 class InboxViewModel @Inject constructor(
     private val getMessagesUseCase: GetMessagesUseCase,
     private val getCategoriesUseCase: GetCategoriesUseCase
 ) : ViewModel() {
-    private val _messages = MutableStateFlow<List<Message>>(emptyList())
-    val messages: StateFlow<List<Message>> = _messages
 
-    private val _categories = MutableStateFlow<List<NotificationCategory>>(emptyList())
-    val categories: StateFlow<List<NotificationCategory>> = _categories
+    private val _uiState = MutableStateFlow<InboxUiState>(InboxUiState.Loading)
+    val uiState: StateFlow<InboxUiState> = _uiState.asStateFlow()
 
     init {
+        refresh()
+        // Optional: keep polling for real-time updates if needed,
+        // but for now we'll just implement a refresh mechanism.
         viewModelScope.launch {
             while (isActive) {
-                fetchInboxData()
-                delay(10000)
+                delay(15000)
+                silentRefresh()
             }
         }
     }
 
+    fun refresh() {
+        viewModelScope.launch {
+            _uiState.value = InboxUiState.Loading
+            fetchInboxData()
+        }
+    }
+
+    private suspend fun silentRefresh() {
+        fetchInboxData()
+    }
+
     private suspend fun fetchInboxData() {
         val catResult = getCategoriesUseCase()
-        if (catResult is Resource.Success) {
-            _categories.value = catResult.data
-        }
-
         val msgResult = getMessagesUseCase()
-        if (msgResult is Resource.Success) {
-            _messages.value = msgResult.data
+
+        if (catResult is Resource.Success && msgResult is Resource.Success) {
+            val categories = catResult.data
+            val conversations = msgResult.data.sortedByDescending { it.lastTimestamp }
+
+            if (categories.isEmpty() && conversations.isEmpty()) {
+                _uiState.value = InboxUiState.Empty
+            } else {
+                _uiState.value = InboxUiState.Success(categories, conversations)
+            }
+        } else if (catResult is Resource.Error || msgResult is Resource.Error) {
+            val errorMessage = when {
+                catResult is Resource.Error -> catResult.message
+                msgResult is Resource.Error -> msgResult.message
+                else -> "Unknown Error"
+            }
+            // Only transition to Error state if we don't already have Success data (for silent refresh)
+            if (_uiState.value !is InboxUiState.Success) {
+                _uiState.value = InboxUiState.Error(errorMessage)
+            }
         }
     }
 }


### PR DESCRIPTION
This PR refactors the message page (Inbox) to use a unified state model (Loading, Success, Empty, Error) and a more robust Conversation domain model. Key changes include:
- Renaming the internal 'Message' model to 'Conversation' and adding fields for last message, last time, and unread count.
- Introducing 'InboxUiState' in 'InboxViewModel' to manage list loading, empty, and error states reliably.
- Implementing descending sort for conversations based on the last message timestamp.
- Adding Pull-to-Refresh functionality and dedicated views for empty and error states.
- Updating the UI to display numeric unread badges and ensuring seamless navigation to the chat screen.

Fixes #81

---
*PR created automatically by Jules for task [11667699949105076160](https://jules.google.com/task/11667699949105076160) started by @zx2121651*