### PR TITLE
Establish Core Messaging Main Link (Send, Fetch, Retry)

### DIFF
--- a/DouyinBackend/biz/service/message_service.go
+++ b/DouyinBackend/biz/service/message_service.go
@@ -34,21 +34,26 @@ func (s *MessageService) SendMessage(fromUserID uint, toUserID uint, content str
 func (s *MessageService) GetChatHistory(userID uint, toUserID uint, preMsgTime int64) ([]model.Message, error) {
 	var messages []model.Message
 
-	query := db.DB.Where(
+	baseQuery := db.DB.Where(
 		"(from_user_id = ? AND to_user_id = ?) OR (from_user_id = ? AND to_user_id = ?)",
 		userID, toUserID, toUserID, userID,
-	).Order("created_at asc") // Clients typically append newer messages to the bottom of the feed
+	)
 
 	if preMsgTime > 0 {
-		// Proper cursor pagination avoiding duplication and ensuring exactly-once delivery
+		// Fetch new messages since preMsgTime in chronological order
 		cursorTime := time.UnixMilli(preMsgTime)
-		query = query.Where("created_at > ?", cursorTime)
-	}
-
-	// Protect against overwhelming the server with massive chat history dumps
-	// Hard limit sets a safe boundary for a single page request
-	if err := query.Limit(100).Find(&messages).Error; err != nil {
-		return nil, err
+		if err := baseQuery.Where("created_at > ?", cursorTime).Order("created_at asc").Limit(100).Find(&messages).Error; err != nil {
+			return nil, err
+		}
+	} else {
+		// Initial fetch: get latest 100 messages in reverse chronological order
+		if err := baseQuery.Order("created_at desc").Limit(100).Find(&messages).Error; err != nil {
+			return nil, err
+		}
+		// Reverse to chronological order (Ascending) for client display
+		for i, j := 0, len(messages)-1; i < j; i, j = i+1, j-1 {
+			messages[i], messages[j] = messages[j], messages[i]
+		}
 	}
 
 	return messages, nil

--- a/DouyinBackend/biz/service/message_service_test.go
+++ b/DouyinBackend/biz/service/message_service_test.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/douyin/backend/biz/dal/db"
+	"github.com/douyin/backend/biz/dal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessageService_GetChatHistory(t *testing.T) {
+	setupTestDBInteraction()
+
+	messageService := NewMessageService()
+
+	user1 := model.User{Username: "sender", Name: "sender"}
+	user2 := model.User{Username: "receiver", Name: "receiver"}
+	db.DB.Create(&user1)
+	db.DB.Create(&user2)
+
+	// Create 5 messages with clear time gaps
+	for i := 1; i <= 5; i++ {
+		msg := model.Message{
+			FromUserID: user1.ID,
+			ToUserID:   user2.ID,
+			Content:    "message",
+		}
+		db.DB.Create(&msg)
+		// Larger sleep to ensure distinct created_at and avoid precision issues
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Run("Initial fetch (preMsgTime = 0)", func(t *testing.T) {
+		messages, err := messageService.GetChatHistory(user1.ID, user2.ID, 0)
+		assert.NoError(t, err)
+		assert.Equal(t, 5, len(messages))
+
+		// Check chronological order (Ascending)
+		for i := 0; i < len(messages)-1; i++ {
+			assert.True(t, messages[i].CreatedAt.Before(messages[i+1].CreatedAt))
+		}
+	})
+
+	t.Run("Polling fetch (preMsgTime > 0)", func(t *testing.T) {
+		messages, err := messageService.GetChatHistory(user1.ID, user2.ID, 0)
+		assert.NoError(t, err)
+
+		// Use a timestamp that is between messages[2] and messages[3]
+		// Since we have 100ms gap, adding 50ms is safe.
+		lastMsgTime := messages[2].CreatedAt.UnixMilli() + 50
+
+		newMessages, err := messageService.GetChatHistory(user1.ID, user2.ID, lastMsgTime)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(newMessages))
+		assert.Equal(t, messages[3].ID, newMessages[0].ID)
+		assert.Equal(t, messages[4].ID, newMessages[1].ID)
+	})
+}

--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/AppNavigation.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/AppNavigation.kt
@@ -86,11 +86,7 @@ fun AppNavHost(
                 navArgument("userName") { type = NavType.StringType }
             )
         ) { backStackEntry ->
-            val userId = backStackEntry.arguments?.getLong("userId") ?: 0L
-            val userName = backStackEntry.arguments?.getString("userName") ?: "User"
             ChatScreen(
-                userId = userId,
-                userName = userName,
                 onBack = { navController.popBackStack() }
             )
         }

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/domain/model/ChatModels.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/domain/model/ChatModels.kt
@@ -1,10 +1,16 @@
 package com.app.douyin.pro.feature.inbox.domain.model
 
 data class ChatMessage(
-    val id: Long,
+    val id: Long = 0,
+    val localId: String = "",
     val toUserId: Long,
     val fromUserId: Long,
     val content: String,
     val createTime: Long,
-    val isMine: Boolean // true if fromUserId == currentUserId
+    val isMine: Boolean, // true if fromUserId == currentUserId
+    val status: MessageStatus = MessageStatus.SUCCESS
 )
+
+enum class MessageStatus {
+    SENDING, SUCCESS, FAILED
+}

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/ChatScreen.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/ChatScreen.kt
@@ -3,14 +3,16 @@ package com.app.douyin.pro.feature.inbox.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -32,18 +34,12 @@ import java.util.Locale
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChatScreen(
-    userId: Long,
-    userName: String,
     onBack: () -> Unit,
     viewModel: ChatViewModel = hiltViewModel()
 ) {
     val messages by viewModel.messages.collectAsState()
     var inputText by remember { mutableStateOf("") }
     val listState = rememberLazyListState()
-
-    LaunchedEffect(userId) {
-        viewModel.initChat(userId)
-    }
 
     LaunchedEffect(messages.size) {
         if (messages.isNotEmpty()) {
@@ -54,7 +50,7 @@ fun ChatScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(userName, color = Color.White, fontWeight = FontWeight.Bold, fontSize = 18.sp) },
+                title = { Text(viewModel.userName, color = Color.White, fontWeight = FontWeight.Bold, fontSize = 18.sp) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.Filled.ArrowBack, contentDescription = "Back", tint = Color.White)
@@ -73,8 +69,27 @@ fun ChatScreen(
                 contentPadding = PaddingValues(16.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                items(messages) { msg ->
-                    ChatBubble(message = msg)
+                itemsIndexed(messages) { index, msg ->
+                    // Time Grouping: Show time if gap > 5 minutes
+                    val showTime = if (index == 0) {
+                        true
+                    } else {
+                        val prevMsg = messages[index - 1]
+                        msg.createTime - prevMsg.createTime > 5 * 60 * 1000
+                    }
+
+                    if (showTime) {
+                        val format = SimpleDateFormat("MM-dd HH:mm", Locale.getDefault())
+                        val timeStr = format.format(Date(msg.createTime))
+                        Box(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), contentAlignment = Alignment.Center) {
+                            Text(timeStr, color = Color.Gray, fontSize = 12.sp)
+                        }
+                    }
+
+                    ChatBubble(
+                        message = msg,
+                        onRetry = { viewModel.retrySendMessage(msg.localId) }
+                    )
                 }
             }
 
@@ -129,14 +144,39 @@ fun ChatScreen(
 }
 
 @Composable
-fun ChatBubble(message: ChatMessage) {
+fun ChatBubble(
+    message: ChatMessage,
+    onRetry: () -> Unit
+) {
     val format = SimpleDateFormat("HH:mm", Locale.getDefault())
     val timeStr = format.format(Date(message.createTime))
 
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = if (message.isMine) Arrangement.End else Arrangement.Start
+        horizontalArrangement = if (message.isMine) Arrangement.End else Arrangement.Start,
+        verticalAlignment = Alignment.CenterVertically
     ) {
+        if (message.isMine) {
+            when (message.status) {
+                com.app.douyin.pro.feature.inbox.domain.model.MessageStatus.SENDING -> {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp).padding(end = 8.dp),
+                        strokeWidth = 2.dp,
+                        color = Color.Gray
+                    )
+                }
+                com.app.douyin.pro.feature.inbox.domain.model.MessageStatus.FAILED -> {
+                    Icon(
+                        Icons.Filled.Error,
+                        contentDescription = "Retry",
+                        tint = Color.Red,
+                        modifier = Modifier.size(20.dp).padding(end = 8.dp).clickable { onRetry() }
+                    )
+                }
+                else -> {}
+            }
+        }
+
         Column(horizontalAlignment = if (message.isMine) Alignment.End else Alignment.Start) {
             Box(
                 modifier = Modifier

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/vm/ChatViewModel.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/vm/ChatViewModel.kt
@@ -1,34 +1,40 @@
 package com.app.douyin.pro.feature.inbox.ui.vm
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.app.douyin.pro.feature.inbox.domain.model.ChatMessage
+import com.app.douyin.pro.feature.inbox.domain.model.MessageStatus
 import com.app.douyin.pro.feature.inbox.domain.usecase.GetChatHistoryUseCase
 import com.app.douyin.pro.feature.inbox.domain.usecase.SendMessageUseCase
+import com.app.douyin.pro.lib.media.auth.AuthManager
 import com.app.douyin.pro.lib.media.model.Resource
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import java.util.UUID
 import javax.inject.Inject
 
 @HiltViewModel
 class ChatViewModel @Inject constructor(
     private val getChatHistoryUseCase: GetChatHistoryUseCase,
-    private val sendMessageUseCase: SendMessageUseCase
+    private val sendMessageUseCase: SendMessageUseCase,
+    private val authManager: AuthManager,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
     private val _messages = MutableStateFlow<List<ChatMessage>>(emptyList())
     val messages: StateFlow<List<ChatMessage>> = _messages.asStateFlow()
 
-    private var currentToUserId: Long = -1
+    private val currentToUserId: Long = savedStateHandle.get<Long>("userId") ?: -1L
+    val userName: String = savedStateHandle.get<String>("userName") ?: "User"
 
-    fun initChat(toUserId: Long) {
-        currentToUserId = toUserId
-
+    init {
         // Initial fetch
         fetchMessages()
 
@@ -43,11 +49,72 @@ class ChatViewModel @Inject constructor(
 
     private fun fetchMessages() {
         if (currentToUserId == -1L) return
+        val lastSuccessfulMsgTime = _messages.value
+            .filter { it.status == MessageStatus.SUCCESS && it.id != 0L }
+            .maxByOrNull { it.createTime }?.createTime ?: 0L
+
         viewModelScope.launch {
-            // Fetch without cursor for simplicity here (always get latest 100)
-            when (val result = getChatHistoryUseCase(currentToUserId, null)) {
+            when (val result = getChatHistoryUseCase(currentToUserId, lastSuccessfulMsgTime)) {
                 is Resource.Success -> {
-                    _messages.value = result.data
+                    mergeMessages(result.data)
+                }
+                else -> {}
+            }
+        }
+    }
+
+    private fun mergeMessages(newMessages: List<ChatMessage>) {
+        if (newMessages.isEmpty()) return
+        _messages.update { currentList ->
+            val merged = currentList.toMutableList()
+            newMessages.forEach { newMsg ->
+                // Check if this server message matches an optimistic message
+                // Since we don't have localId on server, we match by content and sender/receiver and time proximity
+                val optimisticMatch = merged.find {
+                    it.status != MessageStatus.SUCCESS &&
+                            it.content == newMsg.content &&
+                            it.fromUserId == newMsg.fromUserId &&
+                            Math.abs(it.createTime - newMsg.createTime) < 10000 // 10s window
+                }
+
+                if (optimisticMatch != null) {
+                    // Replace optimistic message with server message
+                    val index = merged.indexOf(optimisticMatch)
+                    merged[index] = newMsg
+                } else if (merged.none { it.id == newMsg.id }) {
+                    // Add if not already present
+                    merged.add(newMsg)
+                }
+            }
+            merged.sortedBy { it.createTime }
+        }
+    }
+
+    fun retrySendMessage(localId: String) {
+        val message = _messages.value.find { it.localId == localId } ?: return
+        if (message.status != MessageStatus.FAILED) return
+
+        _messages.update { list ->
+            list.map {
+                if (it.localId == localId) it.copy(status = MessageStatus.SENDING) else it
+            }
+        }
+
+        viewModelScope.launch {
+            when (sendMessageUseCase(currentToUserId, message.content)) {
+                is Resource.Success -> {
+                    _messages.update { list ->
+                        list.map {
+                            if (it.localId == localId) it.copy(status = MessageStatus.SUCCESS) else it
+                        }
+                    }
+                }
+                is Resource.Error -> {
+                    _messages.update { list ->
+                        list.map {
+                            if (it.localId == localId) it.copy(status = MessageStatus.FAILED) else it
+                        }
+                    }
                 }
                 else -> {}
             }
@@ -56,11 +123,36 @@ class ChatViewModel @Inject constructor(
 
     fun sendMessage(content: String) {
         if (currentToUserId == -1L || content.isBlank()) return
+
+        val localId = UUID.randomUUID().toString()
+        val currentUserId = authManager.getUserId()
+        val optimisticMsg = ChatMessage(
+            localId = localId,
+            toUserId = currentToUserId,
+            fromUserId = currentUserId,
+            content = content,
+            createTime = System.currentTimeMillis(),
+            isMine = true,
+            status = MessageStatus.SENDING
+        )
+
+        _messages.update { it + optimisticMsg }
+
         viewModelScope.launch {
             when (sendMessageUseCase(currentToUserId, content)) {
                 is Resource.Success -> {
-                    // Instantly refetch or add optimistically. Refetch for simplicity.
-                    fetchMessages()
+                    _messages.update { list ->
+                        list.map {
+                            if (it.localId == localId) it.copy(status = MessageStatus.SUCCESS) else it
+                        }
+                    }
+                }
+                is Resource.Error -> {
+                    _messages.update { list ->
+                        list.map {
+                            if (it.localId == localId) it.copy(status = MessageStatus.FAILED) else it
+                        }
+                    }
                 }
                 else -> {}
             }


### PR DESCRIPTION
This PR establishes the minimum viable main link for the chat feature. It covers historical message loading, optimistic sending, failure perception, and retry mechanisms.

Key improvements:
- Dual-mode message fetching in the backend for efficient history loading and polling.
- Optimistic UI updates in the Android app: messages appear immediately with 'SENDING' status.
- Robust message deduplication and merging logic in the ViewModel.
- Clear visual feedback for message states (Sending, Success, Failed).
- Interactive retry for failed messages.
- State preservation via SavedStateHandle.
- Automatic scrolling to the bottom on new messages.
- Time-based grouping of messages (5-minute threshold).

Fixes #82

---
*PR created automatically by Jules for task [7421809564897345431](https://jules.google.com/task/7421809564897345431) started by @zx2121651*