### PR TITLE
Unread Count Aggregation and Read Recovery Framework

### DIFF
--- a/DouyinBackend/biz/dal/model/message.go
+++ b/DouyinBackend/biz/dal/model/message.go
@@ -6,7 +6,8 @@ import (
 
 type Message struct {
 	gorm.Model
-	ToUserID   uint   `gorm:"index;not null"` // 接收者 ID
-	FromUserID uint   `gorm:"index;not null"` // 发送者 ID
+	ToUserID   uint   `gorm:"index;not null"`     // 接收者 ID
+	FromUserID uint   `gorm:"index;not null"`     // 发送者 ID
 	Content    string `gorm:"type:text;not null"` // 消息内容
+	IsRead     bool   `gorm:"default:false"`      // 是否已读
 }

--- a/DouyinBackend/biz/handler/message/message_handler.go
+++ b/DouyinBackend/biz/handler/message/message_handler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/douyin/backend/biz/common/errno"
 	"github.com/douyin/backend/biz/common/utils"
+	"github.com/douyin/backend/biz/model/common"
 	message_model "github.com/douyin/backend/biz/model/message"
 	"github.com/douyin/backend/biz/service"
 )
@@ -72,5 +73,118 @@ func MessageChat(ctx context.Context, c *app.RequestContext) {
 
 	utils.SendResponse(c, errno.Success, map[string]interface{}{
 		"message_list": messageList,
+	})
+}
+
+func MessageActionList(ctx context.Context, c *app.RequestContext) {
+	userIDRaw, exists := c.Get("user_id")
+	if !exists {
+		utils.SendResponse(c, errno.AuthErr, nil)
+		return
+	}
+	userID := userIDRaw.(uint)
+
+	conversations, err := messageService.GetConversationList(userID)
+	if err != nil {
+		utils.SendResponse(c, errno.ServiceErr.WithMessage(err.Error()), nil)
+		return
+	}
+
+	type ConversationDTO struct {
+		User        *common.User `json:"user"`
+		LastMessage string       `json:"last_message"`
+		CreateTime  int64        `json:"create_time"`
+		UnreadCount int64        `json:"unread_count"`
+	}
+
+	var conversationList []ConversationDTO
+	for _, conv := range conversations {
+		conversationList = append(conversationList, ConversationDTO{
+			User: &common.User{
+				ID:            int64(conv.User.ID),
+				Name:          conv.User.Name,
+				FollowCount:   conv.User.FollowCount,
+				FollowerCount: conv.User.FollowerCount,
+				Avatar:        conv.User.Avatar,
+			},
+			LastMessage: conv.LastMessage.Content,
+			CreateTime:  conv.LastMessage.CreatedAt.UnixMilli(),
+			UnreadCount: conv.UnreadCount,
+		})
+	}
+
+	if conversationList == nil {
+		conversationList = []ConversationDTO{}
+	}
+
+	utils.SendResponse(c, errno.Success, map[string]interface{}{
+		"conversation_list": conversationList,
+	})
+}
+
+func UnreadCount(ctx context.Context, c *app.RequestContext) {
+	userIDRaw, exists := c.Get("user_id")
+	if !exists {
+		utils.SendResponse(c, errno.AuthErr, nil)
+		return
+	}
+	userID := userIDRaw.(uint)
+
+	count, err := messageService.GetTotalUnreadCount(userID)
+	if err != nil {
+		utils.SendResponse(c, errno.ServiceErr.WithMessage(err.Error()), nil)
+		return
+	}
+
+	utils.SendResponse(c, errno.Success, map[string]interface{}{
+		"unread_count": count,
+	})
+}
+
+func GetNotifications(ctx context.Context, c *app.RequestContext) {
+	userIDRaw, exists := c.Get("user_id")
+	if !exists {
+		utils.SendResponse(c, errno.AuthErr, nil)
+		return
+	}
+	userID := userIDRaw.(uint)
+
+	// Simple pagination
+	notifications, err := messageService.GetNotifications(userID, 100, 0)
+	if err != nil {
+		utils.SendResponse(c, errno.ServiceErr.WithMessage(err.Error()), nil)
+		return
+	}
+
+	var notificationList []message_model.SystemNotification
+	for _, n := range notifications {
+		var fromUser *common.User
+		if n.FromUser.ID != 0 {
+			fromUser = &common.User{
+				ID:            int64(n.FromUser.ID),
+				Name:          n.FromUser.Name,
+				FollowCount:   n.FromUser.FollowCount,
+				FollowerCount: n.FromUser.FollowerCount,
+				IsFollow:      false, // Logic for IsFollow would need relationship check
+				Avatar:        n.FromUser.Avatar,
+			}
+		}
+
+		notificationList = append(notificationList, message_model.SystemNotification{
+			ID:         int64(n.ID),
+			FromUser:   fromUser,
+			Type:       string(n.Type),
+			Content:    n.Content,
+			CreateTime: n.CreatedAt.UnixMilli(),
+			IsRead:     n.IsRead,
+		})
+	}
+
+	if notificationList == nil {
+		notificationList = []message_model.SystemNotification{}
+	}
+
+	utils.SendResponse(c, errno.Success, map[string]interface{}{
+		"notification_list": notificationList,
 	})
 }

--- a/DouyinBackend/biz/router/router.go
+++ b/DouyinBackend/biz/router/router.go
@@ -53,6 +53,9 @@ func Register(h *server.Hertz) {
 	messageGroup := api.Group("/message")
 	messageGroup.POST("/action/", mw.AuthMiddleware(), message.MessageAction)
 	messageGroup.GET("/chat/", mw.AuthMiddleware(), message.MessageChat)
+	messageGroup.GET("/action/list/", mw.AuthMiddleware(), message.MessageActionList)
+	messageGroup.GET("/unread/", mw.AuthMiddleware(), message.UnreadCount)
+	messageGroup.GET("/notifications/", mw.AuthMiddleware(), message.GetNotifications)
 
 	// Search
 	searchGroup := api.Group("/search")

--- a/DouyinBackend/biz/service/message_service.go
+++ b/DouyinBackend/biz/service/message_service.go
@@ -30,6 +30,7 @@ func (s *MessageService) SendMessage(fromUserID uint, toUserID uint, content str
 
 	return db.DB.Create(&message).Error
 }
+
 // GetChatHistory utilizes cursor-based pagination (preMsgTime) to reliably fetch historical messages without missing any due to concurrent inserts.
 func (s *MessageService) GetChatHistory(userID uint, toUserID uint, preMsgTime int64) ([]model.Message, error) {
 	var messages []model.Message
@@ -56,7 +57,69 @@ func (s *MessageService) GetChatHistory(userID uint, toUserID uint, preMsgTime i
 		}
 	}
 
+	// Mark messages from toUserID to userID as read
+	if len(messages) > 0 {
+		db.DB.Model(&model.Message{}).
+			Where("from_user_id = ? AND to_user_id = ? AND is_read = ?", toUserID, userID, false).
+			Update("is_read", true)
+	}
+
 	return messages, nil
+}
+
+// GetTotalUnreadCount aggregates unread private messages and system notifications
+func (s *MessageService) GetTotalUnreadCount(userID uint) (int64, error) {
+	var msgCount int64
+	if err := db.DB.Model(&model.Message{}).Where("to_user_id = ? AND is_read = ?", userID, false).Count(&msgCount).Error; err != nil {
+		return 0, err
+	}
+
+	var notifyCount int64
+	if err := db.DB.Model(&model.SystemNotification{}).Where("to_user_id = ? AND is_read = ?", userID, false).Count(&notifyCount).Error; err != nil {
+		return msgCount, nil
+	}
+
+	return msgCount + notifyCount, nil
+}
+
+type Conversation struct {
+	User        model.User
+	LastMessage model.Message
+	UnreadCount int64
+}
+
+func (s *MessageService) GetConversationList(userID uint) ([]Conversation, error) {
+	var conversations []Conversation
+
+	// Find all unique users interacted with
+	var userIDs []uint
+	db.DB.Model(&model.Message{}).
+		Select("DISTINCT CASE WHEN from_user_id = ? THEN to_user_id ELSE from_user_id END", userID).
+		Where("from_user_id = ? OR to_user_id = ?", userID, userID).
+		Find(&userIDs)
+
+	for _, otherID := range userIDs {
+		var lastMsg model.Message
+		db.DB.Where("(from_user_id = ? AND to_user_id = ?) OR (from_user_id = ? AND to_user_id = ?)",
+			userID, otherID, otherID, userID).
+			Order("created_at desc").First(&lastMsg)
+
+		var unreadCount int64
+		db.DB.Model(&model.Message{}).
+			Where("from_user_id = ? AND to_user_id = ? AND is_read = ?", otherID, userID, false).
+			Count(&unreadCount)
+
+		var otherUser model.User
+		db.DB.First(&otherUser, otherID)
+
+		conversations = append(conversations, Conversation{
+			User:        otherUser,
+			LastMessage: lastMsg,
+			UnreadCount: unreadCount,
+		})
+	}
+
+	return conversations, nil
 }
 
 // GetUnreadNotificationCount aggregates the total unread system notifications (likes, follows) for a specific user

--- a/DouyinBackend/biz/service/message_service_test.go
+++ b/DouyinBackend/biz/service/message_service_test.go
@@ -56,4 +56,37 @@ func TestMessageService_GetChatHistory(t *testing.T) {
 		assert.Equal(t, messages[3].ID, newMessages[0].ID)
 		assert.Equal(t, messages[4].ID, newMessages[1].ID)
 	})
+
+	t.Run("Read recovery in GetChatHistory", func(t *testing.T) {
+		// user1 sent messages to user2. They should be unread for user2 initially.
+		var count int64
+		db.DB.Model(&model.Message{}).Where("to_user_id = ? AND is_read = ?", user2.ID, false).Count(&count)
+		assert.Equal(t, int64(5), count)
+
+		// user2 fetches chat history. Messages should be marked as read.
+		_, err := messageService.GetChatHistory(user2.ID, user1.ID, 0)
+		assert.NoError(t, err)
+
+		db.DB.Model(&model.Message{}).Where("to_user_id = ? AND is_read = ?", user2.ID, false).Count(&count)
+		assert.Equal(t, int64(0), count)
+	})
+
+	t.Run("GetTotalUnreadCount", func(t *testing.T) {
+		// Clear existing notifications/messages if any
+		db.DB.Exec("DELETE FROM messages")
+		db.DB.Exec("DELETE FROM system_notifications")
+
+		// 3 unread messages
+		for i := 0; i < 3; i++ {
+			db.DB.Create(&model.Message{ToUserID: user1.ID, FromUserID: user2.ID, Content: "unread", IsRead: false})
+		}
+		// 2 unread notifications
+		for i := 0; i < 2; i++ {
+			db.DB.Create(&model.SystemNotification{ToUserID: user1.ID, Type: "like", IsRead: false})
+		}
+
+		count, err := messageService.GetTotalUnreadCount(user1.ID)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(5), count)
+	})
 }

--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/AppNavigation.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/AppNavigation.kt
@@ -1,7 +1,9 @@
 package com.app.douyin.pro.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -13,6 +15,7 @@ import com.app.douyin.pro.feature.edit.ui.EditScreen
 import com.app.douyin.pro.feature.home.ui.FriendsScreen
 import com.app.douyin.pro.feature.home.ui.HomeScreen
 import com.app.douyin.pro.feature.home.ui.SearchScreen
+import com.app.douyin.pro.feature.home.ui.SearchPlayerScreen
 import com.app.douyin.pro.feature.inbox.ui.ChatScreen
 import com.app.douyin.pro.feature.inbox.ui.InboxScreen
 import com.app.douyin.pro.feature.mall.ui.MallScreen

--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/MainBottomBar.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/MainBottomBar.kt
@@ -15,6 +15,8 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -25,12 +27,16 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
+import com.app.douyin.pro.lib.media.interaction.MessageUnreadManager
+
 @Composable
 fun MainBottomBar(
     currentRoute: String?,
+    unreadManager: MessageUnreadManager,
     onNavigate: (String) -> Unit
 ) {
     val isDarkBgRoute = NavigationConfigs.isDarkBackgroundRoute(currentRoute)
+    val unreadCount by unreadManager.totalUnreadCount.collectAsState()
 
     NavigationBar(
         containerColor = if (isDarkBgRoute) Color.Transparent else Color.White,
@@ -46,12 +52,10 @@ fun MainBottomBar(
                     } else {
                         BadgedBox(
                             badge = {
-                                if (item.badgeCount > 0) {
+                                if (item == MainTab.Inbox && unreadCount > 0) {
                                     Badge {
-                                        Text(item.badgeCount.toString())
+                                        Text(if (unreadCount > 99) "99+" else unreadCount.toString())
                                     }
-                                } else if (item.showDot) {
-                                    Badge()
                                 }
                             }
                         ) {

--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/MainScreen.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/MainScreen.kt
@@ -9,11 +9,14 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.app.douyin.pro.feature.inbox.ui.vm.InboxViewModel
 
 @androidx.compose.foundation.ExperimentalFoundationApi
 @Composable
 fun MainScreen() {
     val navController = rememberNavController()
+    val inboxViewModel: InboxViewModel = hiltViewModel()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
 
@@ -22,6 +25,7 @@ fun MainScreen() {
             if (!NavigationConfigs.shouldHideBottomBar(currentRoute)) {
                 MainBottomBar(
                     currentRoute = currentRoute,
+                    unreadManager = inboxViewModel.unreadManager,
                     onNavigate = { route ->
                         navController.navigate(route) {
                             popUpTo(navController.graph.findStartDestination().id) {

--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/MainTab.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/MainTab.kt
@@ -9,9 +9,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 sealed class MainTab(
     val route: String,
     val title: String,
-    val icon: ImageVector?,
-    val badgeCount: Int = 0,
-    val showDot: Boolean = false
+    val icon: ImageVector?
 ) {
     data object Home : MainTab(NavRoutes.HOME, "首页", Icons.Filled.Home)
     data object Friends : MainTab(NavRoutes.FRIENDS, "朋友", Icons.Filled.Person)

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/data/source/InboxDataSource.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/data/source/InboxDataSource.kt
@@ -23,21 +23,21 @@ class RemoteInboxDataSource @Inject constructor(
         try {
             if (!authManager.isLoggedIn()) return emptyList()
             val token = authManager.requireToken()
-            val response = apiService.getNotifications(token)
+            val response = apiService.getConversationList(token)
             if (response.statusCode == 0) {
                 val format = SimpleDateFormat("MM-dd", Locale.getDefault())
-                val list = response.notificationList
+                val list = response.conversationList
                 if (list != null) {
                     return list.map { dto ->
                         Conversation(
-                            id = dto.id.toString(),
-                            avatarUrl = dto.fromUser?.avatar ?: "https://api.dicebear.com/7.x/avataaars/png?seed=${dto.id}",
-                            name = dto.fromUser?.name ?: "系统通知",
+                            id = dto.user.id.toString(),
+                            avatarUrl = dto.user.avatar ?: "https://api.dicebear.com/7.x/avataaars/png?seed=${dto.user.id}",
+                            name = dto.user.name,
                             lastTime = format.format(Date(dto.createTime)),
                             lastTimestamp = dto.createTime,
-                            lastMessage = dto.content,
-                            isOfficial = dto.type == "system",
-                            unreadCount = if (dto.isRead) 0 else 1,
+                            lastMessage = dto.lastMessage,
+                            isOfficial = false,
+                            unreadCount = dto.unreadCount.toInt(),
                             isLive = false
                         )
                     }

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/vm/ChatViewModel.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/vm/ChatViewModel.kt
@@ -8,6 +8,7 @@ import com.app.douyin.pro.feature.inbox.domain.model.MessageStatus
 import com.app.douyin.pro.feature.inbox.domain.usecase.GetChatHistoryUseCase
 import com.app.douyin.pro.feature.inbox.domain.usecase.SendMessageUseCase
 import com.app.douyin.pro.lib.media.auth.AuthManager
+import com.app.douyin.pro.lib.media.interaction.MessageUnreadManager
 import com.app.douyin.pro.lib.media.model.Resource
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
@@ -25,6 +26,7 @@ class ChatViewModel @Inject constructor(
     private val getChatHistoryUseCase: GetChatHistoryUseCase,
     private val sendMessageUseCase: SendMessageUseCase,
     private val authManager: AuthManager,
+    private val unreadManager: MessageUnreadManager,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -57,6 +59,9 @@ class ChatViewModel @Inject constructor(
             when (val result = getChatHistoryUseCase(currentToUserId, lastSuccessfulMsgTime)) {
                 is Resource.Success -> {
                     mergeMessages(result.data)
+                    if (result.data.isNotEmpty()) {
+                        unreadManager.refreshUnreadCount()
+                    }
                 }
                 else -> {}
             }

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/vm/InboxViewModel.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/vm/InboxViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import com.app.douyin.pro.lib.media.interaction.MessageUnreadManager
 
 sealed class InboxUiState {
     object Loading : InboxUiState()
@@ -29,7 +30,8 @@ sealed class InboxUiState {
 @HiltViewModel
 class InboxViewModel @Inject constructor(
     private val getMessagesUseCase: GetMessagesUseCase,
-    private val getCategoriesUseCase: GetCategoriesUseCase
+    private val getCategoriesUseCase: GetCategoriesUseCase,
+    val unreadManager: MessageUnreadManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<InboxUiState>(InboxUiState.Loading)
@@ -61,6 +63,7 @@ class InboxViewModel @Inject constructor(
     private suspend fun fetchInboxData() {
         val catResult = getCategoriesUseCase()
         val msgResult = getMessagesUseCase()
+        unreadManager.refreshUnreadCount()
 
         if (catResult is Resource.Success && msgResult is Resource.Success) {
             val categories = catResult.data

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/interaction/MessageUnreadManager.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/interaction/MessageUnreadManager.kt
@@ -1,0 +1,64 @@
+package com.app.douyin.pro.lib.media.interaction
+
+import com.app.douyin.pro.lib.media.auth.AuthManager
+import com.app.douyin.pro.lib.media.network.DouyinApiService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MessageUnreadManager @Inject constructor(
+    private val apiService: DouyinApiService,
+    private val authManager: AuthManager
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val _totalUnreadCount = MutableStateFlow(0)
+    val totalUnreadCount: StateFlow<Int> = _totalUnreadCount.asStateFlow()
+
+    init {
+        scope.launch {
+            authManager.isLoggedInFlow.collectLatest { isLoggedIn ->
+                if (isLoggedIn) {
+                    startPolling()
+                } else {
+                    _totalUnreadCount.value = 0
+                }
+            }
+        }
+    }
+
+    private fun startPolling() {
+        scope.launch {
+            while (isActive && authManager.isLoggedIn()) {
+                refreshUnreadCount()
+                delay(10000) // Poll every 10 seconds
+            }
+        }
+    }
+
+    fun refreshUnreadCount() {
+        scope.launch {
+            try {
+                if (authManager.isLoggedIn()) {
+                    val token = authManager.requireToken()
+                    val response = apiService.getUnreadCount(token)
+                    if (response.statusCode == 0) {
+                        _totalUnreadCount.value = response.unreadCount.toInt()
+                    }
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+}

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/network/DouyinApiService.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/network/DouyinApiService.kt
@@ -11,6 +11,7 @@ import com.app.douyin.pro.lib.media.network.model.UnreadCountResponse
 
 import com.app.douyin.pro.lib.media.network.model.CommentActionResponse
 import com.app.douyin.pro.lib.media.network.model.MessageChatResponse
+import com.app.douyin.pro.lib.media.network.model.ConversationListResponse
 import com.app.douyin.pro.lib.media.network.model.MessageActionResponse
 import com.app.douyin.pro.lib.media.network.model.SearchVideoResponse
 import com.app.douyin.pro.lib.media.network.model.SearchUserResponse
@@ -33,6 +34,11 @@ interface DouyinApiService {
         @Query("pre_msg_time") preMsgTime: Long? = null,
         @Query("token") token: String
     ): MessageChatResponse
+
+    @GET("douyin/message/action/list/")
+    suspend fun getConversationList(
+        @Query("token") token: String
+    ): ConversationListResponse
 
     @POST("douyin/message/action/")
     suspend fun sendMessage(

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/network/model/ChatResponse.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/network/model/ChatResponse.kt
@@ -20,3 +20,16 @@ data class ChatMessageDto(
     @SerializedName("content") val content: String,
     @SerializedName("create_time") val createTime: Long
 )
+
+data class ConversationListResponse(
+    @SerializedName("status_code") val statusCode: Int,
+    @SerializedName("status_msg") val statusMsg: String?,
+    @SerializedName("conversation_list") val conversationList: List<ConversationDto>?
+)
+
+data class ConversationDto(
+    @SerializedName("user") val user: UserDto,
+    @SerializedName("last_message") val lastMessage: String,
+    @SerializedName("create_time") val createTime: Long,
+    @SerializedName("unread_count") val unreadCount: Long
+)


### PR DESCRIPTION
This PR establishes the foundational framework for unread message counts and read state recovery in the Douyin Lite application. It includes backend model updates, service logic for aggregation, and new API endpoints. On the frontend, it introduces a global MessageUnreadManager to synchronize unread counts across the bottom bar, inbox, and chat screens, ensuring a consistent user experience.

Fixes #83

---
*PR created automatically by Jules for task [11433475889647474661](https://jules.google.com/task/11433475889647474661) started by @zx2121651*