### PR TITLE
Unified Notification Center Implementation

### DIFF
--- a/DouyinBackend/biz/handler/message/message_handler.go
+++ b/DouyinBackend/biz/handler/message/message_handler.go
@@ -175,6 +175,7 @@ func GetNotifications(ctx context.Context, c *app.RequestContext) {
 			FromUser:   fromUser,
 			Type:       string(n.Type),
 			Content:    n.Content,
+			TargetID:   int64(n.TargetID),
 			CreateTime: n.CreatedAt.UnixMilli(),
 			IsRead:     n.IsRead,
 		})

--- a/DouyinBackend/biz/model/message/notification_api.go
+++ b/DouyinBackend/biz/model/message/notification_api.go
@@ -3,12 +3,13 @@ package message
 import "github.com/douyin/backend/biz/model/common"
 
 type SystemNotification struct {
-	ID         int64       `json:"id"`
+	ID         int64        `json:"id"`
 	FromUser   *common.User `json:"from_user,omitempty"`
-	Type       string      `json:"type"`
-	Content    string      `json:"content"`
-	CreateTime int64       `json:"create_time"`
-	IsRead     bool        `json:"is_read"`
+	Type       string       `json:"type"`
+	Content    string       `json:"content"`
+	TargetID   int64        `json:"target_id"`
+	CreateTime int64        `json:"create_time"`
+	IsRead     bool         `json:"is_read"`
 }
 
 type NotificationListResponse struct {

--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/AppNavigation.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/AppNavigation.kt
@@ -18,6 +18,7 @@ import com.app.douyin.pro.feature.home.ui.SearchScreen
 import com.app.douyin.pro.feature.home.ui.SearchPlayerScreen
 import com.app.douyin.pro.feature.inbox.ui.ChatScreen
 import com.app.douyin.pro.feature.inbox.ui.InboxScreen
+import com.app.douyin.pro.feature.inbox.ui.NotificationCenterScreen
 import com.app.douyin.pro.feature.mall.ui.MallScreen
 import com.app.douyin.pro.feature.profile.ui.ProfileScreen
 import com.app.douyin.pro.feature.record.ui.PublishScreen
@@ -78,9 +79,19 @@ fun AppNavHost(
             )
         }
         composable(NavRoutes.INBOX) {
-            InboxScreen(onNavigateToChat = { userId, userName ->
-                navController.navigate(NavRoutes.buildChatRoute(userId, userName))
-            })
+            InboxScreen(
+                onNavigateToChat = { userId, userName ->
+                    navController.navigate(NavRoutes.buildChatRoute(userId, userName))
+                },
+                onNavigateToNotifications = {
+                    navController.navigate(NavRoutes.NOTIFICATIONS)
+                }
+            )
+        }
+        composable(NavRoutes.NOTIFICATIONS) {
+            NotificationCenterScreen(
+                onBack = { navController.popBackStack() }
+            )
         }
         composable(
             route = NavRoutes.CHAT,

--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/NavRoutes.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/NavRoutes.kt
@@ -5,6 +5,7 @@ object NavRoutes {
     const val FRIENDS = "friends"
     const val RECORD = "record"
     const val INBOX = "inbox"
+    const val NOTIFICATIONS = "notifications"
     const val ME = "me"
 
     const val EDIT = "edit?videoUri={videoUri}"

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/data/InboxRepository.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/data/InboxRepository.kt
@@ -3,6 +3,7 @@ package com.app.douyin.pro.feature.inbox.data
 import com.app.douyin.pro.feature.inbox.data.source.InboxDataSource
 import com.app.douyin.pro.feature.inbox.domain.model.Conversation
 import com.app.douyin.pro.feature.inbox.domain.model.NotificationCategory
+import com.app.douyin.pro.feature.inbox.domain.model.NotificationItem
 import com.app.douyin.pro.lib.media.model.Resource
 import com.app.douyin.pro.lib.media.model.AppError
 import javax.inject.Inject
@@ -18,4 +19,10 @@ class InboxRepository @Inject constructor(
         Resource.Error(e.message ?: "Unknown Error", AppError.NetworkError)
     }
     suspend fun getCategories(): Resource<List<NotificationCategory>> = Resource.Success(dataSource.getCategories())
+
+    suspend fun getNotifications(): Resource<List<NotificationItem>> = try {
+        Resource.Success(dataSource.getNotifications())
+    } catch (e: Exception) {
+        Resource.Error(e.message ?: "Unknown Error", AppError.NetworkError)
+    }
 }

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/data/source/InboxDataSource.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/data/source/InboxDataSource.kt
@@ -2,6 +2,9 @@ package com.app.douyin.pro.feature.inbox.data.source
 
 import com.app.douyin.pro.feature.inbox.domain.model.Conversation
 import com.app.douyin.pro.feature.inbox.domain.model.NotificationCategory
+import com.app.douyin.pro.feature.inbox.domain.model.NotificationItem
+import com.app.douyin.pro.feature.inbox.domain.model.NotificationType
+import com.app.douyin.pro.lib.media.model.UserModel
 import com.app.douyin.pro.lib.media.network.DouyinApiService
 import com.app.douyin.pro.lib.media.auth.AuthManager
 import javax.inject.Inject
@@ -12,6 +15,7 @@ import java.util.Locale
 interface InboxDataSource {
     suspend fun getMessages(): List<Conversation>
     suspend fun getCategories(): List<NotificationCategory>
+    suspend fun getNotifications(): List<NotificationItem>
 }
 
 class RemoteInboxDataSource @Inject constructor(
@@ -68,5 +72,35 @@ class RemoteInboxDataSource @Inject constructor(
             NotificationCategory("favorite", "互动消息", unreadCount > 0, if (unreadCount > 0) unreadCount.toString() else null),
             NotificationCategory("alternate_email", "系统通知", false, null)
         )
+    }
+
+    override suspend fun getNotifications(): List<NotificationItem> {
+        try {
+            if (!authManager.isLoggedIn()) return emptyList()
+            val token = authManager.requireToken()
+            val response = apiService.getNotifications(token)
+            if (response.statusCode == 0) {
+                return response.notificationList?.map { dto ->
+                    NotificationItem(
+                        id = dto.id,
+                        fromUser = dto.fromUser?.let {
+                            UserModel(
+                                id = it.id,
+                                name = it.name,
+                                avatar = it.avatar
+                            )
+                        },
+                        type = NotificationType.fromString(dto.type),
+                        content = dto.content,
+                        targetId = dto.targetId,
+                        createTime = dto.createTime,
+                        isRead = dto.isRead
+                    )
+                } ?: emptyList()
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        return emptyList()
     }
 }

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/domain/model/NotificationModels.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/domain/model/NotificationModels.kt
@@ -1,0 +1,26 @@
+package com.app.douyin.pro.feature.inbox.domain.model
+
+import com.app.douyin.pro.lib.media.model.UserModel
+
+enum class NotificationType(val value: String) {
+    LIKE("like"),
+    COMMENT("comment"),
+    FOLLOW("follow"),
+    SYSTEM("system");
+
+    companion object {
+        fun fromString(type: String): NotificationType {
+            return values().find { it.value == type } ?: SYSTEM
+        }
+    }
+}
+
+data class NotificationItem(
+    val id: Long,
+    val fromUser: UserModel?,
+    val type: NotificationType,
+    val content: String,
+    val targetId: Long,
+    val createTime: Long,
+    val isRead: Boolean
+)

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/domain/usecase/GetNotificationsUseCase.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/domain/usecase/GetNotificationsUseCase.kt
@@ -1,0 +1,12 @@
+package com.app.douyin.pro.feature.inbox.domain.usecase
+
+import com.app.douyin.pro.feature.inbox.data.InboxRepository
+import com.app.douyin.pro.feature.inbox.domain.model.NotificationItem
+import com.app.douyin.pro.lib.media.model.Resource
+import javax.inject.Inject
+
+class GetNotificationsUseCase @Inject constructor(
+    private val repository: InboxRepository
+) {
+    suspend operator fun invoke(): Resource<List<NotificationItem>> = repository.getNotifications()
+}

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/InboxScreen.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/InboxScreen.kt
@@ -41,6 +41,7 @@ val ErrorColorDot = Color(0xFFFF0050)
 @Composable
 fun InboxScreen(
     onNavigateToChat: (Long, String) -> Unit = { _, _ -> },
+    onNavigateToNotifications: () -> Unit = {},
     viewModel: InboxViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -89,7 +90,7 @@ fun InboxScreen(
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(bottom = 80.dp)
                     ) {
-                        item { NotificationCategoriesRow(state.categories) }
+                        item { NotificationCategoriesRow(state.categories, onNavigateToNotifications) }
                         item { Spacer(modifier = Modifier.height(8.dp)) }
                         items(state.conversations, key = { it.id }) { conversation ->
                             ConversationItemRow(conversation, onNavigateToChat)
@@ -153,19 +154,25 @@ fun ErrorInboxView(message: String, onRetry: () -> Unit) {
 }
 
 @Composable
-fun NotificationCategoriesRow(categories: List<NotificationCategory>) {
+fun NotificationCategoriesRow(
+    categories: List<NotificationCategory>,
+    onNavigateToNotifications: () -> Unit
+) {
     Row(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         categories.forEach { category ->
-            CategoryItem(category)
+            CategoryItem(category, onNavigateToNotifications)
         }
     }
 }
 
 @Composable
-fun CategoryItem(category: NotificationCategory) {
+fun CategoryItem(
+    category: NotificationCategory,
+    onNavigateToNotifications: () -> Unit
+) {
     val iconColor = when(category.type) {
         "group" -> Color(0xFFE2E2E2)
         "favorite" -> Color(0xFFFFB3B6)
@@ -180,7 +187,14 @@ fun CategoryItem(category: NotificationCategory) {
         else -> Icons.Default.Email
     }
 
-    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.clickable { }) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.clickable {
+            if (category.type == "favorite" || category.type == "alternate_email") {
+                onNavigateToNotifications()
+            }
+        }
+    ) {
         Box(modifier = Modifier.size(56.dp).clip(RoundedCornerShape(16.dp)).background(DarkSurfaceContainer), contentAlignment = Alignment.Center) {
             Icon(icon, category.title, tint = iconColor, modifier = Modifier.size(28.dp))
             if (category.hasDot) {

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/NotificationCenterScreen.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/NotificationCenterScreen.kt
@@ -1,0 +1,188 @@
+package com.app.douyin.pro.feature.inbox.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
+import com.app.douyin.pro.feature.inbox.domain.model.NotificationItem
+import com.app.douyin.pro.feature.inbox.domain.model.NotificationType
+import com.app.douyin.pro.feature.inbox.ui.vm.NotificationUiState
+import com.app.douyin.pro.feature.inbox.ui.vm.NotificationViewModel
+import java.text.SimpleDateFormat
+import java.util.*
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NotificationCenterScreen(
+    onBack: () -> Unit,
+    viewModel: NotificationViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("通知", color = TextPrimary, fontSize = 18.sp, fontWeight = FontWeight.Bold) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = TextPrimary)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = DarkSurface)
+            )
+        },
+        containerColor = DarkSurface
+    ) { paddingValues ->
+        Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+            when (val state = uiState) {
+                is NotificationUiState.Loading -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator(color = Color(0xFFFF0050))
+                    }
+                }
+                is NotificationUiState.Empty -> {
+                    EmptyNotificationView()
+                }
+                is NotificationUiState.Error -> {
+                    ErrorNotificationView(state.message) { viewModel.refresh() }
+                }
+                is NotificationUiState.Success -> {
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items(state.notifications, key = { it.id }) { notification ->
+                            NotificationItemRow(notification)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun NotificationItemRow(notification: NotificationItem) {
+    val dateFormat = SimpleDateFormat("MM-dd HH:mm", Locale.getDefault())
+    val timeStr = dateFormat.format(Date(notification.createTime))
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (notification.fromUser != null) {
+            AsyncImage(
+                model = notification.fromUser.avatar ?: "https://api.dicebear.com/7.x/avataaars/png?seed=${notification.fromUser.id}",
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .background(DarkSurfaceContainer),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(Icons.Default.Notifications, contentDescription = null, tint = Color(0xFFFF0050), modifier = Modifier.size(24.dp))
+            }
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = notification.fromUser?.name ?: "系统通知",
+                    color = TextPrimary,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = timeStr,
+                    color = TextSecondary,
+                    fontSize = 12.sp
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = notification.content,
+                color = TextPrimary,
+                fontSize = 14.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        if (!notification.isRead) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .clip(CircleShape)
+                    .background(Color(0xFFFF0050))
+            )
+        }
+    }
+}
+
+@Composable
+fun EmptyNotificationView() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            Icons.Default.Notifications,
+            contentDescription = null,
+            tint = TextSecondary,
+            modifier = Modifier.size(64.dp)
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text("暂无通知", color = TextSecondary, fontSize = 14.sp)
+    }
+}
+
+@Composable
+fun ErrorNotificationView(message: String, onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("加载失败", color = TextPrimary, fontSize = 16.sp, fontWeight = FontWeight.Bold)
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(message, color = TextSecondary, fontSize = 13.sp, textAlign = TextAlign.Center)
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(
+            onClick = onRetry,
+            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF0050))
+        ) {
+            Text("重试")
+        }
+    }
+}

--- a/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/vm/NotificationViewModel.kt
+++ b/DouyinLite/feature_inbox/src/main/java/com/app/douyin/pro/feature/inbox/ui/vm/NotificationViewModel.kt
@@ -1,0 +1,49 @@
+package com.app.douyin.pro.feature.inbox.ui.vm
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.app.douyin.pro.feature.inbox.domain.model.NotificationItem
+import com.app.douyin.pro.feature.inbox.domain.usecase.GetNotificationsUseCase
+import com.app.douyin.pro.lib.media.model.Resource
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+sealed class NotificationUiState {
+    object Loading : NotificationUiState()
+    data class Success(val notifications: List<NotificationItem>) : NotificationUiState()
+    object Empty : NotificationUiState()
+    data class Error(val message: String) : NotificationUiState()
+}
+
+@HiltViewModel
+class NotificationViewModel @Inject constructor(
+    private val getNotificationsUseCase: GetNotificationsUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<NotificationUiState>(NotificationUiState.Loading)
+    val uiState: StateFlow<NotificationUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            _uiState.value = NotificationUiState.Loading
+            val result = getNotificationsUseCase()
+            if (result is Resource.Success) {
+                if (result.data.isEmpty()) {
+                    _uiState.value = NotificationUiState.Empty
+                } else {
+                    _uiState.value = NotificationUiState.Success(result.data)
+                }
+            } else if (result is Resource.Error) {
+                _uiState.value = NotificationUiState.Error(result.message)
+            }
+        }
+    }
+}

--- a/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/network/model/NotificationResponse.kt
+++ b/DouyinLite/lib_media/src/main/java/com/app/douyin/pro/lib/media/network/model/NotificationResponse.kt
@@ -19,6 +19,7 @@ data class NotificationDto(
     @SerializedName("from_user") val fromUser: UserDto?,
     @SerializedName("type") val type: String,
     @SerializedName("content") val content: String,
+    @SerializedName("target_id") val targetId: Long,
     @SerializedName("create_time") val createTime: Long,
     @SerializedName("is_read") val isRead: Boolean
 )


### PR DESCRIPTION
This PR establishes a unified notification center architecture for DouyinLite. It introduces a common model and UI container for all types of notifications (Likes, Comments, Follows, and System updates), ensuring they are clearly separated from private conversations in the Inbox.

Key changes:
- Backend: Updated `SystemNotification` API response to include `target_id`.
- Frontend:
    - Added `NotificationItem` domain model and `NotificationType` enum.
    - Implemented `GetNotificationsUseCase` and updated `InboxRepository`/`DataSource`.
    - Created `NotificationCenterScreen` and `NotificationViewModel` for a unified list display.
    - Updated `InboxScreen` entry points to navigate to the new notification center.
    - Verified backend service tests and frontend compilation.

Fixes #84

---
*PR created automatically by Jules for task [2161975585947924251](https://jules.google.com/task/2161975585947924251) started by @zx2121651*