### PR TITLE
Dual-state model for Personal Profile (Self/Visitor)

### DIFF
--- a/DouyinLite/feature_profile/build.gradle.kts
+++ b/DouyinLite/feature_profile/build.gradle.kts
@@ -54,4 +54,10 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.coil.compose)
+
+    // Test
+    testImplementation(libs.junit)
+    testImplementation("org.mockito:mockito-core:5.11.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0")
+    testImplementation("androidx.arch.core:core-testing:2.2.0")
 }

--- a/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/data/source/ProfileDataSource.kt
+++ b/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/data/source/ProfileDataSource.kt
@@ -35,7 +35,9 @@ class RemoteProfileDataSource @Inject constructor(
                 likes = "0", // Currently we don't return total likes received, default to 0
                 avatar = user.avatar,
                 backgroundImage = user.backgroundImage,
-                signature = user.signature
+                signature = user.signature,
+                workCount = 0, // Will be updated by ViewModel or separate call
+                favoritedCount = 0
             )
         }
         throw Exception(response.statusMsg ?: "Failed to load profile")
@@ -92,5 +94,7 @@ data class ProfileInfo(
     val likes: String,
     val avatar: String? = null,
     val backgroundImage: String? = null,
-    val signature: String? = null
+    val signature: String? = null,
+    val workCount: Int = 0,
+    val favoritedCount: Long = 0
 )

--- a/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/ui/ProfileScreen.kt
+++ b/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/ui/ProfileScreen.kt
@@ -38,7 +38,9 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.app.douyin.pro.feature.profile.viewmodel.ProfileViewModel
+import com.app.douyin.pro.feature.profile.viewmodel.ProfileViewMode
 import com.app.douyin.pro.lib.media.auth.SessionState
+import com.app.douyin.pro.lib.media.util.CountFormatter
 import kotlin.random.Random
 import kotlin.math.roundToInt
 
@@ -53,14 +55,16 @@ fun ProfileScreen(
     val profileInfo by viewModel.profileInfo.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
     val publishedVideos by viewModel.publishedVideos.collectAsState()
+    val viewMode by viewModel.viewMode.collectAsState()
 
     val username = profileInfo?.username ?: "加载中..."
     val douyinId = profileInfo?.douyinId ?: ""
     val followers = profileInfo?.followers ?: "0"
     val following = profileInfo?.following?.toString() ?: "0"
-    val likes = profileInfo?.likes ?: "0"
+    val likes = profileInfo?.favoritedCount?.let { CountFormatter.format(it) } ?: "0"
     val signature = profileInfo?.signature?.takeIf { it.isNotEmpty() } ?: "专注 Android 性能优化与 Jetpack Compose 动效开发。\n不写 Bug，只写诗。✨"
     val avatar = profileInfo?.avatar?.takeIf { it.isNotEmpty() } ?: "https://lh3.googleusercontent.com/aida-public/AB6AXuAFRJnvPgLJTZNlp2beH3rKkgrIq79yAByHrNztp31d3S5Ql5HDcVsXOtOffLNhtuX4qaajnkwFgdAFL5OCuwdLzNBs9QDqqeiJejfbJPzXVeArU5eX10395R9he1IM-Eoy2kh6lmFA_v6n8auwbHfT6iBKAZdZODWoz0wWWJn57dDE7AybZhChYpQ6vVgt7ESF1A6VaNFSrjxMK6MuHftCkoxICASpEx6ooT2VDLv3mlsVbLQNXGa1uCeoOWCamXI699HkQHUvmOk"
+    val backgroundImage = profileInfo?.backgroundImage
 
     val darkBg = Color(0xFF161823)
     val grayText = Color(0xFF8E8E93)
@@ -125,6 +129,27 @@ fun ProfileScreen(
             .background(darkBg)
             .nestedScroll(nestedScrollConnection)
     ) {
+        // Background Image
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(160.dp)
+                .graphicsLayer {
+                    translationY = scrollOffset * 0.5f
+                }
+        ) {
+            if (backgroundImage != null) {
+                AsyncImage(
+                    model = backgroundImage,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            } else {
+                Box(modifier = Modifier.fillMaxSize().background(Color(0xFF2E2E2E)))
+            }
+        }
+
         // Sticky Header / Collapsing logic
         Column(
             modifier = Modifier
@@ -137,12 +162,13 @@ fun ProfileScreen(
                 }
         ) {
             // Invisible spacer for top bar placeholder within the scrolling header
-            Spacer(modifier = Modifier.height(topBarHeight).statusBarsPadding())
+            Spacer(modifier = Modifier.height(100.dp)) // Pull down content
 
             // Profile Header Content
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .background(darkBg, RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
                     .padding(horizontal = 16.dp)
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
@@ -214,65 +240,12 @@ fun ProfileScreen(
                 Spacer(modifier = Modifier.height(20.dp))
 
                 // Action Buttons
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    if (viewModel.isSelf()) {
-                        Button(
-                            onClick = { viewModel.logout() },
-                            modifier = Modifier.weight(1f).height(40.dp),
-                            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2E2E2E)),
-                            shape = RoundedCornerShape(8.dp),
-                            contentPadding = PaddingValues(0.dp)
-                        ) {
-                            Text("退出登录", fontSize = 14.sp, fontWeight = FontWeight.Bold)
-                        }
-                        Button(
-                            onClick = {},
-                            modifier = Modifier.weight(1f).height(40.dp),
-                            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2E2E2E)),
-                            shape = RoundedCornerShape(8.dp),
-                            contentPadding = PaddingValues(0.dp)
-                        ) {
-                            Text("编辑资料", fontSize = 14.sp, fontWeight = FontWeight.Bold)
-                        }
-                    } else {
-                        val isFollowed = profileInfo?.isFollowed ?: false
-                        Button(
-                            onClick = { viewModel.toggleFollow() },
-                            modifier = Modifier.weight(1f).height(40.dp),
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = if (isFollowed) Color(0xFF2E2E2E) else Color(0xFFFE2C55)
-                            ),
-                            shape = RoundedCornerShape(8.dp),
-                            contentPadding = PaddingValues(0.dp)
-                        ) {
-                            Text(
-                                if (isFollowed) "已关注" else "关注",
-                                fontSize = 14.sp,
-                                fontWeight = FontWeight.Bold,
-                                color = Color.White
-                            )
-                        }
-                        Button(
-                            onClick = {},
-                            modifier = Modifier.weight(1f).height(40.dp),
-                            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2E2E2E)),
-                            shape = RoundedCornerShape(8.dp),
-                            contentPadding = PaddingValues(0.dp)
-                        ) {
-                            Text("私信", fontSize = 14.sp, fontWeight = FontWeight.Bold, color = Color.White)
-                        }
-                    }
-                    Box(
-                        modifier = Modifier
-                            .size(40.dp)
-                            .clip(RoundedCornerShape(8.dp))
-                            .background(Color(0xFF2E2E2E))
-                            .clickable { },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(Icons.Filled.Share, contentDescription = null, tint = Color.White, modifier = Modifier.size(20.dp))
-                    }
-                }
+                ProfileActionButtons(
+                    viewMode = viewMode,
+                    isFollowed = profileInfo?.isFollowed ?: false,
+                    onToggleFollow = { viewModel.toggleFollow() },
+                    onLogout = { viewModel.logout() }
+                )
             }
 
             Spacer(modifier = Modifier.height(24.dp))
@@ -386,7 +359,7 @@ fun ProfileScreen(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            if (viewModel.isSelf()) {
+            if (viewMode == ProfileViewMode.SELF) {
                 Icon(Icons.Filled.Add, contentDescription = null, tint = Color.White)
             } else {
                 Icon(
@@ -409,6 +382,73 @@ fun ProfileScreen(
                 Icon(Icons.Filled.Search, contentDescription = null, tint = Color.White)
                 Icon(Icons.Filled.Menu, contentDescription = null, tint = Color.White)
             }
+        }
+    }
+}
+
+@Composable
+fun ProfileActionButtons(
+    viewMode: ProfileViewMode,
+    isFollowed: Boolean,
+    onToggleFollow: () -> Unit,
+    onLogout: () -> Unit
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (viewMode == ProfileViewMode.SELF) {
+            Button(
+                onClick = onLogout,
+                modifier = Modifier.weight(1f).height(40.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2E2E2E)),
+                shape = RoundedCornerShape(8.dp),
+                contentPadding = PaddingValues(0.dp)
+            ) {
+                Text("退出登录", fontSize = 14.sp, fontWeight = FontWeight.Bold)
+            }
+            Button(
+                onClick = {},
+                modifier = Modifier.weight(1f).height(40.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2E2E2E)),
+                shape = RoundedCornerShape(8.dp),
+                contentPadding = PaddingValues(0.dp)
+            ) {
+                Text("编辑资料", fontSize = 14.sp, fontWeight = FontWeight.Bold)
+            }
+        } else {
+            Button(
+                onClick = onToggleFollow,
+                modifier = Modifier.weight(1f).height(40.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = if (isFollowed) Color(0xFF2E2E2E) else Color(0xFFFE2C55)
+                ),
+                shape = RoundedCornerShape(8.dp),
+                contentPadding = PaddingValues(0.dp)
+            ) {
+                Text(
+                    if (isFollowed) "已关注" else "关注",
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White
+                )
+            }
+            Button(
+                onClick = {},
+                modifier = Modifier.weight(1f).height(40.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2E2E2E)),
+                shape = RoundedCornerShape(8.dp),
+                contentPadding = PaddingValues(0.dp)
+            ) {
+                Text("私信", fontSize = 14.sp, fontWeight = FontWeight.Bold, color = Color.White)
+            }
+        }
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(Color(0xFF2E2E2E))
+                .clickable { },
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(Icons.Filled.Share, contentDescription = null, tint = Color.White, modifier = Modifier.size(20.dp))
         }
     }
 }

--- a/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/viewmodel/ProfileViewModel.kt
+++ b/DouyinLite/feature_profile/src/main/java/com/app/douyin/pro/feature/profile/viewmodel/ProfileViewModel.kt
@@ -23,6 +23,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+enum class ProfileViewMode {
+    SELF, VISITOR
+}
+
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
     private val getProfileInfoUseCase: GetProfileInfoUseCase,
@@ -33,6 +37,9 @@ class ProfileViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     val userId: Long? = savedStateHandle.get<Long>("userId")?.takeIf { it > 0 }
+
+    private val _viewMode = MutableStateFlow(if (isSelf()) ProfileViewMode.SELF else ProfileViewMode.VISITOR)
+    val viewMode: StateFlow<ProfileViewMode> = _viewMode.asStateFlow()
 
     val sessionState: StateFlow<SessionState> = authRepository.getSessionState()
 
@@ -89,13 +96,20 @@ class ProfileViewModel @Inject constructor(
     fun loadProfile() {
         viewModelScope.launch {
             _isLoading.value = true
+            _viewMode.value = if (isSelf()) ProfileViewMode.SELF else ProfileViewMode.VISITOR
+
+            val videosResult = getPublishedVideosUseCase(userId)
+            val videos = if (videosResult is Resource.Success) videosResult.data else emptyList()
+            _publishedVideos.value = videos
+
             when (val result = getProfileInfoUseCase(userId)) {
-                is Resource.Success -> _profileInfo.value = result.data
+                is Resource.Success -> {
+                    _profileInfo.value = result.data.copy(
+                        workCount = videos.size,
+                        favoritedCount = videos.sumOf { it.likeCount }
+                    )
+                }
                 else -> _profileInfo.value = null
-            }
-            when (val result = getPublishedVideosUseCase(userId)) {
-                is Resource.Success -> _publishedVideos.value = result.data
-                else -> _publishedVideos.value = emptyList()
             }
             _isLoading.value = false
         }

--- a/DouyinLite/feature_profile/src/test/java/com/app/douyin/pro/feature/profile/viewmodel/ProfileViewModelTest.kt
+++ b/DouyinLite/feature_profile/src/test/java/com/app/douyin/pro/feature/profile/viewmodel/ProfileViewModelTest.kt
@@ -1,0 +1,134 @@
+package com.app.douyin.pro.feature.profile.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import com.app.douyin.pro.feature.profile.data.source.ProfileInfo
+import com.app.douyin.pro.feature.profile.domain.usecase.GetProfileInfoUseCase
+import com.app.douyin.pro.feature.profile.domain.usecase.GetPublishedVideosUseCase
+import com.app.douyin.pro.lib.media.auth.AuthManager
+import com.app.douyin.pro.lib.media.auth.AuthRepository
+import com.app.douyin.pro.lib.media.auth.SessionState
+import com.app.douyin.pro.lib.media.interaction.VideoInteractionManager
+import com.app.douyin.pro.lib.media.model.Resource
+import com.app.douyin.pro.lib.media.model.VideoModel
+import com.app.douyin.pro.lib.media.model.UserModel
+import com.app.douyin.pro.lib.media.network.model.UserDto
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+
+@ExperimentalCoroutinesApi
+class ProfileViewModelTest {
+
+    private val getProfileInfoUseCase: GetProfileInfoUseCase = mock(GetProfileInfoUseCase::class.java)
+    private val getPublishedVideosUseCase: GetPublishedVideosUseCase = mock(GetPublishedVideosUseCase::class.java)
+    private val authRepository: AuthRepository = mock(AuthRepository::class.java)
+    private val authManager: AuthManager = mock(AuthManager::class.java)
+    private val interactionManager: VideoInteractionManager = mock(VideoInteractionManager::class.java)
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        val userDto = UserDto(123L, "test", 0, 0, false, null, null, null)
+        `when`(authRepository.getSessionState()).thenReturn(MutableStateFlow(SessionState.LoggedIn(userDto)))
+        `when`(interactionManager.interactionEvents).thenReturn(MutableSharedFlow())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `viewMode should be SELF when userId is null`() = runTest {
+        `when`(authManager.getUserId()).thenReturn(123L)
+        val savedStateHandle = SavedStateHandle()
+
+        val viewModel = ProfileViewModel(
+            getProfileInfoUseCase,
+            getPublishedVideosUseCase,
+            authRepository,
+            authManager,
+            interactionManager,
+            savedStateHandle
+        )
+
+        assertEquals(ProfileViewMode.SELF, viewModel.viewMode.value)
+    }
+
+    @Test
+    fun `viewMode should be SELF when userId matches current user`() = runTest {
+        `when`(authManager.getUserId()).thenReturn(123L)
+        val savedStateHandle = SavedStateHandle(mapOf("userId" to 123L))
+
+        val viewModel = ProfileViewModel(
+            getProfileInfoUseCase,
+            getPublishedVideosUseCase,
+            authRepository,
+            authManager,
+            interactionManager,
+            savedStateHandle
+        )
+
+        assertEquals(ProfileViewMode.SELF, viewModel.viewMode.value)
+    }
+
+    @Test
+    fun `viewMode should be VISITOR when userId is different`() = runTest {
+        `when`(authManager.getUserId()).thenReturn(123L)
+        val savedStateHandle = SavedStateHandle(mapOf("userId" to 456L))
+
+        val viewModel = ProfileViewModel(
+            getProfileInfoUseCase,
+            getPublishedVideosUseCase,
+            authRepository,
+            authManager,
+            interactionManager,
+            savedStateHandle
+        )
+
+        assertEquals(ProfileViewMode.VISITOR, viewModel.viewMode.value)
+    }
+
+    @Test
+    fun `loadProfile should update workCount and favoritedCount`() = runTest {
+        val userId = 123L
+        `when`(authManager.getUserId()).thenReturn(userId)
+        val savedStateHandle = SavedStateHandle(mapOf("userId" to userId))
+
+        val user = UserModel(userId, "test", "avatar")
+        val videos = listOf(
+            VideoModel(1, user, "p1", "c1", "t1", likeCount = 10),
+            VideoModel(2, user, "p2", "c2", "t2", likeCount = 20)
+        )
+        val profileInfo = ProfileInfo(userId, "test", "dy_123", 0, "0", 0, false, "0")
+
+        `when`(getPublishedVideosUseCase(userId)).thenReturn(Resource.Success(videos))
+        `when`(getProfileInfoUseCase(userId)).thenReturn(Resource.Success(profileInfo))
+
+        val viewModel = ProfileViewModel(
+            getProfileInfoUseCase,
+            getPublishedVideosUseCase,
+            authRepository,
+            authManager,
+            interactionManager,
+            savedStateHandle
+        )
+
+        viewModel.loadProfile()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val resultInfo = viewModel.profileInfo.value
+        assertEquals(2, resultInfo?.workCount)
+        assertEquals(30L, resultInfo?.favoritedCount)
+    }
+}


### PR DESCRIPTION
This change refactors the personal profile page into a unified dual-state model, distinguishing between "Self" and "Visitor" perspectives. 

Key improvements:
- **Perspective Logic**: The `ProfileViewModel` now automatically identifies if the current user is viewing their own profile or someone else's based on the `userId` in `SavedStateHandle`.
- **Action Permissions**: Unified UI structure that swaps "Edit Profile" and "Logout" buttons with "Follow" and "Message" buttons for visitors.
- **Data Enrichment**: Added support for background images, work counts, and total likes (favorited count) in the profile header.
- **Top Bar Adaptation**: The top bar icons now change contextually (Add/Post for self, Back for visitors).
- **Verification**: Added unit tests to ensure correct view mode identification and data mapping.

Fixes #85

---
*PR created automatically by Jules for task [883720986420666141](https://jules.google.com/task/883720986420666141) started by @zx2121651*