### PR TITLE
Implement multi-segment recording state machine and timeline model

### DIFF
--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/AppNavigation.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/AppNavigation.kt
@@ -47,8 +47,8 @@ fun AppNavHost(
             FriendsScreen()
         }
         composable(NavRoutes.RECORD) {
-            RecordScreen(onNavigateToEdit = { videoUriStr ->
-                navController.navigate(NavRoutes.buildEditRoute(videoUriStr))
+            RecordScreen(onNavigateToEdit = { segmentsJson ->
+                navController.navigate(NavRoutes.buildEditMultiRoute(segmentsJson))
             })
         }
         composable(
@@ -58,6 +58,19 @@ fun AppNavHost(
             val videoUri = backStackEntry.arguments?.getString("videoUri") ?: ""
             EditScreen(
                 videoUri = videoUri,
+                onClose = { navController.popBackStack() },
+                onNext = { exportedUri ->
+                    navController.navigate(NavRoutes.buildPublishRoute(exportedUri.toString()))
+                }
+            )
+        }
+        composable(
+            route = NavRoutes.EDIT_MULTI,
+            arguments = listOf(navArgument("segments") { type = NavType.StringType })
+        ) { backStackEntry ->
+            val segmentsJson = backStackEntry.arguments?.getString("segments") ?: "[]"
+            EditScreen(
+                segmentsJson = segmentsJson,
                 onClose = { navController.popBackStack() },
                 onNext = { exportedUri ->
                     navController.navigate(NavRoutes.buildPublishRoute(exportedUri.toString()))

--- a/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/NavRoutes.kt
+++ b/DouyinLite/app/src/main/java/com/app/douyin/pro/navigation/NavRoutes.kt
@@ -14,6 +14,11 @@ object NavRoutes {
         return "edit?videoUri=${android.net.Uri.encode(videoUri)}"
     }
 
+    const val EDIT_MULTI = "edit_multi?segments={segments}"
+    fun buildEditMultiRoute(segmentsJson: String): String {
+        return "edit_multi?segments=${android.net.Uri.encode(segmentsJson)}"
+    }
+
     const val CHAT = "chat/{userId}/{userName}"
     fun buildChatRoute(userId: Long, userName: String): String {
         return "chat/$userId/${android.net.Uri.encode(userName)}"

--- a/DouyinLite/feature_edit/build.gradle.kts
+++ b/DouyinLite/feature_edit/build.gradle.kts
@@ -37,6 +37,7 @@ android {
 
 dependencies {
     implementation(project(":lib_media"))
+    implementation(project(":feature_record"))
     implementation(libs.androidx.work.runtime.ktx)
 
     // Hilt

--- a/DouyinLite/feature_edit/src/main/java/com/app/douyin/pro/feature/edit/ui/EditScreen.kt
+++ b/DouyinLite/feature_edit/src/main/java/com/app/douyin/pro/feature/edit/ui/EditScreen.kt
@@ -8,11 +8,13 @@ import android.net.Uri
 @Composable
 fun EditScreen(
     videoUri: String = "",
+    segmentsJson: String = "",
     onClose: () -> Unit = {},
     onNext: (Uri) -> Unit = {}
 ) {
     RealEditScreen(
         videoUri = videoUri,
+        segmentsJson = segmentsJson,
         onClose = onClose,
         onNext = onNext
     )

--- a/DouyinLite/feature_edit/src/main/java/com/app/douyin/pro/feature/edit/ui/screen/EditScreen.kt
+++ b/DouyinLite/feature_edit/src/main/java/com/app/douyin/pro/feature/edit/ui/screen/EditScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.platform.LocalContext
 @Composable
 fun EditScreen(
     videoUri: String,
+    segmentsJson: String = "",
     onClose: () -> Unit,
     onNext: (Uri) -> Unit,
     viewModel: EditViewModel = hiltViewModel()
@@ -36,8 +37,10 @@ fun EditScreen(
     val uiState by viewModel.uiState.collectAsState()
 
     val context = LocalContext.current
-    LaunchedEffect(videoUri) {
-        if (videoUri.isNotEmpty()) {
+    LaunchedEffect(videoUri, segmentsJson) {
+        if (segmentsJson.isNotEmpty()) {
+            viewModel.initProjectWithSegments(segmentsJson)
+        } else if (videoUri.isNotEmpty()) {
             val uri = Uri.parse(videoUri)
             val duration = MediaMetadataUtils.getVideoDurationMs(context, uri)
             viewModel.initProject(uri, if (duration > 0) duration else 15000L)

--- a/DouyinLite/feature_edit/src/main/java/com/app/douyin/pro/feature/edit/ui/vm/EditViewModel.kt
+++ b/DouyinLite/feature_edit/src/main/java/com/app/douyin/pro/feature/edit/ui/vm/EditViewModel.kt
@@ -52,6 +52,29 @@ class EditViewModel @Inject constructor(
         clearHistory()
     }
 
+    fun initProjectWithSegments(segmentsJson: String) {
+        try {
+            val type = object : com.google.gson.reflect.TypeToken<List<com.app.douyin.pro.feature.record.domain.model.RecordSegment>>() {}.type
+            val segments: List<com.app.douyin.pro.feature.record.domain.model.RecordSegment> = Gson().fromJson(segmentsJson, type)
+
+            val clips = segments.map { segment ->
+                ClipItem(
+                    sourceUri = Uri.fromFile(File(segment.filePath)),
+                    sourceDurationMs = segment.durationMs,
+                    endInSourceMs = segment.durationMs
+                )
+            }.toMutableList()
+
+            val videoTrack = EditTrack(type = TrackType.VIDEO, clips = clips)
+            val totalDuration = clips.sumOf { it.getTimelineDurationMs() }
+
+            _uiState.update { it.copy(tracks = listOf(videoTrack), totalDurationMs = totalDuration) }
+            clearHistory()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
     private fun executeCommand(command: EditCommand) {
         val prevState = _uiState.value.tracks.map { it.copy(clips = it.clips.map { c -> c.copy() }.toMutableList()) }
         val nextTracks = command.execute(_uiState.value.tracks)

--- a/DouyinLite/feature_record/build.gradle.kts
+++ b/DouyinLite/feature_record/build.gradle.kts
@@ -83,4 +83,6 @@ dependencies {
     implementation(libs.guava)
     implementation(libs.mediapipe.tasks.vision)
     testImplementation(libs.junit)
+    testImplementation("org.mockito:mockito-inline:4.5.1")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
 }

--- a/DouyinLite/feature_record/src/main/java/com/app/douyin/pro/feature/record/domain/model/RecordSegment.kt
+++ b/DouyinLite/feature_record/src/main/java/com/app/douyin/pro/feature/record/domain/model/RecordSegment.kt
@@ -1,0 +1,6 @@
+package com.app.douyin.pro.feature.record.domain.model
+
+data class RecordSegment(
+    val filePath: String,
+    val durationMs: Long
+)

--- a/DouyinLite/feature_record/src/main/java/com/app/douyin/pro/feature/record/domain/usecase/GetAvailableFiltersUseCase.kt
+++ b/DouyinLite/feature_record/src/main/java/com/app/douyin/pro/feature/record/domain/usecase/GetAvailableFiltersUseCase.kt
@@ -4,7 +4,7 @@ import com.app.douyin.pro.feature.record.data.RecordRepository
 import com.app.douyin.pro.lib.media.model.Resource
 import javax.inject.Inject
 
-class GetAvailableFiltersUseCase @Inject constructor(
+open class GetAvailableFiltersUseCase @Inject constructor(
     private val repository: RecordRepository
 ) {
     suspend operator fun invoke(): Resource<List<com.app.douyin.pro.feature.record.domain.model.FilterEffect>> = repository.getAvailableFilters()

--- a/DouyinLite/feature_record/src/main/java/com/app/douyin/pro/feature/record/ui/RecordScreen.kt
+++ b/DouyinLite/feature_record/src/main/java/com/app/douyin/pro/feature/record/ui/RecordScreen.kt
@@ -35,6 +35,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.app.douyin.pro.feature.record.gl.CameraGLSurfaceView
 import com.app.douyin.pro.feature.record.ui.vm.RecordViewModel
 import com.app.douyin.pro.feature.record.ui.state.PermissionStatus
+import com.app.douyin.pro.feature.record.ui.state.RecordState
 import com.app.douyin.pro.feature.record.util.RecordGuard
 import android.content.Intent
 import android.net.Uri
@@ -189,7 +190,16 @@ fun RecordScreen(
             )
 
             // UI Components
-            TopControls(onClose = { }, onToggleLens = viewModel::toggleLens)
+            Column(modifier = Modifier.fillMaxSize()) {
+                Spacer(modifier = Modifier.height(16.dp))
+                RecordProgressBar(
+                    segments = uiState.segments,
+                    totalDurationMs = uiState.totalDurationMs,
+                    maxDurationMs = 60000L, // 60s limit
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).height(4.dp)
+                )
+                TopControls(onClose = { }, onToggleLens = viewModel::toggleLens)
+            }
 
             SideControls(
                 onShowFilters = { viewModel.setShowFilters(true) },
@@ -223,28 +233,72 @@ fun RecordScreen(
                 )
             }
 
-            RecordButton(
-                isRecording = uiState.isRecording,
-                modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 40.dp),
-                onClick = {
-                    if (uiState.isRecording) {
-                        activeRecording?.stop()
-                        viewModel.setRecording(false)
-                    } else {
-                        val videoFile = File(context.cacheDir, "recorded_${System.currentTimeMillis()}.mp4")
-                        activeRecording = videoCapture?.output
-                            ?.prepareRecording(context, FileOutputOptions.Builder(videoFile).build())
-                            ?.apply { if (uiState.capabilities.hasMic) withAudioEnabled() }
-                            ?.start(ContextCompat.getMainExecutor(context)) { event ->
-                                if (event is VideoRecordEvent.Start) viewModel.setRecording(true)
-                                if (event is VideoRecordEvent.Finalize) {
-                                    viewModel.setRecording(false)
-                                    if (!event.hasError()) onNavigateToEdit(videoFile.absolutePath)
-                                }
-                            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 40.dp)
+            ) {
+                // Delete button (only show when not recording and has segments)
+                if (!uiState.isRecording && uiState.segments.isNotEmpty()) {
+                    IconButton(
+                        onClick = viewModel::deleteLastSegment,
+                        modifier = Modifier
+                            .align(Alignment.CenterStart)
+                            .padding(start = 48.dp)
+                            .size(48.dp)
+                            .background(Color.White.copy(alpha = 0.2f), CircleShape)
+                    ) {
+                        Icon(Icons.Default.Backspace, contentDescription = "Delete Last", tint = Color.White)
                     }
                 }
-            )
+
+                RecordButton(
+                    isRecording = uiState.isRecording,
+                    modifier = Modifier.align(Alignment.Center),
+                    onClick = {
+                        if (uiState.isRecording) {
+                            activeRecording?.stop()
+                        } else {
+                            val videoFile = File(context.cacheDir, "recorded_${System.currentTimeMillis()}.mp4")
+                            activeRecording = videoCapture?.output
+                                ?.prepareRecording(context, FileOutputOptions.Builder(videoFile).build())
+                                ?.apply { if (uiState.capabilities.hasMic) withAudioEnabled() }
+                                ?.start(ContextCompat.getMainExecutor(context)) { event ->
+                                    if (event is VideoRecordEvent.Start) {
+                                        viewModel.startRecording()
+                                    }
+                                    if (event is VideoRecordEvent.Finalize) {
+                                        if (!event.hasError()) {
+                                            val duration = event.recordingStats.recordedDurationNanos / 1_000_000
+                                            viewModel.pauseRecording(videoFile.absolutePath, duration)
+                                        } else {
+                                            viewModel.setRecording(false)
+                                        }
+                                    }
+                                }
+                        }
+                    }
+                )
+
+                // Done button (show when has segments)
+                if (!uiState.isRecording && uiState.segments.isNotEmpty()) {
+                    IconButton(
+                        onClick = {
+                            viewModel.completeRecording()
+                            val segmentsJson = com.google.gson.Gson().toJson(uiState.segments)
+                            onNavigateToEdit(segmentsJson)
+                        },
+                        modifier = Modifier
+                            .align(Alignment.CenterEnd)
+                            .padding(end = 48.dp)
+                            .size(48.dp)
+                            .background(Color(0xFFFF2C55), CircleShape)
+                    ) {
+                        Icon(Icons.Default.Check, contentDescription = "Done", tint = Color.White)
+                    }
+                }
+            }
         } else {
             PermissionGuardView(
                 status = uiState.permissionStatus,
@@ -367,6 +421,33 @@ fun FilterPanel(filters: List<com.app.douyin.pro.feature.record.domain.model.Fil
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+fun RecordProgressBar(
+    segments: List<com.app.douyin.pro.feature.record.domain.model.RecordSegment>,
+    totalDurationMs: Long,
+    maxDurationMs: Long,
+    modifier: Modifier = Modifier
+) {
+    Canvas(modifier = modifier) {
+        val width = size.width
+        val height = size.height
+
+        // Background
+        drawRect(color = Color.White.copy(alpha = 0.3f), size = size)
+
+        var currentX = 0f
+        segments.forEach { segment ->
+            val segmentWidth = (segment.durationMs.toFloat() / maxDurationMs) * width
+            drawRect(
+                color = Color(0xFFFF2C55),
+                topLeft = Offset(currentX, 0f),
+                size = androidx.compose.ui.geometry.Size(segmentWidth - 2.dp.toPx(), height)
+            )
+            currentX += segmentWidth
         }
     }
 }

--- a/DouyinLite/feature_record/src/main/java/com/app/douyin/pro/feature/record/ui/state/RecordState.kt
+++ b/DouyinLite/feature_record/src/main/java/com/app/douyin/pro/feature/record/ui/state/RecordState.kt
@@ -1,0 +1,9 @@
+package com.app.douyin.pro.feature.record.ui.state
+
+enum class RecordState {
+    IDLE,
+    RECORDING,
+    PAUSED,
+    COMPLETED,
+    ERROR
+}

--- a/DouyinLite/feature_record/src/main/java/com/app/douyin/pro/feature/record/ui/state/RecordUiState.kt
+++ b/DouyinLite/feature_record/src/main/java/com/app/douyin/pro/feature/record/ui/state/RecordUiState.kt
@@ -2,6 +2,7 @@ package com.app.douyin.pro.feature.record.ui.state
 
 import androidx.camera.core.CameraSelector
 import com.app.douyin.pro.feature.record.domain.model.FilterEffect
+import com.app.douyin.pro.feature.record.domain.model.RecordSegment
 
 enum class PermissionStatus {
     IDLE,
@@ -23,5 +24,8 @@ data class RecordUiState(
     val showFilters: Boolean = false,
     val selectedFilter: FilterEffect? = FilterEffect("原片", false, null),
     val permissionStatus: PermissionStatus = PermissionStatus.IDLE,
-    val capabilities: RecordCapability = RecordCapability()
+    val capabilities: RecordCapability = RecordCapability(),
+    val segments: List<RecordSegment> = emptyList(),
+    val totalDurationMs: Long = 0L,
+    val currentState: RecordState = RecordState.IDLE
 )

--- a/DouyinLite/feature_record/src/main/java/com/app/douyin/pro/feature/record/ui/vm/RecordStateMachine.kt
+++ b/DouyinLite/feature_record/src/main/java/com/app/douyin/pro/feature/record/ui/vm/RecordStateMachine.kt
@@ -1,0 +1,30 @@
+package com.app.douyin.pro.feature.record.ui.vm
+
+import com.app.douyin.pro.feature.record.ui.state.RecordState
+
+class RecordStateMachine(
+    initialState: RecordState = RecordState.IDLE,
+    private val onStateChanged: (RecordState) -> Unit
+) {
+    var currentState: RecordState = initialState
+        private set
+
+    fun transitionTo(newState: RecordState): Boolean {
+        if (isValidTransition(currentState, newState)) {
+            currentState = newState
+            onStateChanged(newState)
+            return true
+        }
+        return false
+    }
+
+    private fun isValidTransition(from: RecordState, to: RecordState): Boolean {
+        return when (from) {
+            RecordState.IDLE -> to == RecordState.RECORDING || to == RecordState.ERROR
+            RecordState.RECORDING -> to == RecordState.PAUSED || to == RecordState.COMPLETED || to == RecordState.ERROR
+            RecordState.PAUSED -> to == RecordState.RECORDING || to == RecordState.COMPLETED || to == RecordState.IDLE || to == RecordState.ERROR
+            RecordState.COMPLETED -> to == RecordState.IDLE
+            RecordState.ERROR -> to == RecordState.IDLE
+        }
+    }
+}

--- a/DouyinLite/feature_record/src/main/java/com/app/douyin/pro/feature/record/ui/vm/RecordViewModel.kt
+++ b/DouyinLite/feature_record/src/main/java/com/app/douyin/pro/feature/record/ui/vm/RecordViewModel.kt
@@ -7,7 +7,9 @@ import com.app.douyin.pro.feature.record.domain.usecase.CountdownUseCase
 import android.content.Context
 import com.app.douyin.pro.feature.record.domain.usecase.GetAvailableFiltersUseCase
 import com.app.douyin.pro.feature.record.ui.state.PermissionStatus
+import com.app.douyin.pro.feature.record.domain.model.RecordSegment
 import com.app.douyin.pro.feature.record.ui.state.RecordCapability
+import com.app.douyin.pro.feature.record.ui.state.RecordState
 import com.app.douyin.pro.feature.record.ui.state.RecordUiState
 import com.app.douyin.pro.feature.record.util.RecordGuard
 import com.app.douyin.pro.lib.media.model.Resource
@@ -27,6 +29,10 @@ class RecordViewModel @Inject constructor(
 
     private val _availableFilters = MutableStateFlow<List<com.app.douyin.pro.feature.record.domain.model.FilterEffect>>(emptyList())
     val availableFilters: StateFlow<List<com.app.douyin.pro.feature.record.domain.model.FilterEffect>> = _availableFilters.asStateFlow()
+
+    private val stateMachine = RecordStateMachine { newState ->
+        _uiState.update { it.copy(currentState = newState) }
+    }
 
     init {
         loadFilters()
@@ -79,6 +85,51 @@ class RecordViewModel @Inject constructor(
                 _uiState.update { it.copy(countdownTime = time) }
             }
         }
+    }
+
+    fun startRecording() {
+        if (stateMachine.transitionTo(RecordState.RECORDING)) {
+            _uiState.update { it.copy(isRecording = true) }
+        }
+    }
+
+    fun pauseRecording(filePath: String, durationMs: Long) {
+        if (stateMachine.transitionTo(RecordState.PAUSED)) {
+            val newSegment = RecordSegment(filePath, durationMs)
+            _uiState.update { state ->
+                val newSegments = state.segments + newSegment
+                state.copy(
+                    isRecording = false,
+                    segments = newSegments,
+                    totalDurationMs = newSegments.sumOf { it.durationMs }
+                )
+            }
+        }
+    }
+
+    fun deleteLastSegment() {
+        _uiState.update { state ->
+            if (state.segments.isNotEmpty()) {
+                val newSegments = state.segments.dropLast(1)
+                state.copy(
+                    segments = newSegments,
+                    totalDurationMs = newSegments.sumOf { it.durationMs },
+                    currentState = if (newSegments.isEmpty()) RecordState.IDLE else RecordState.PAUSED
+                )
+            } else {
+                state
+            }
+        }
+        // Sync state machine state
+        if (_uiState.value.segments.isEmpty()) {
+            stateMachine.transitionTo(RecordState.IDLE)
+        } else {
+            stateMachine.transitionTo(RecordState.PAUSED)
+        }
+    }
+
+    fun completeRecording() {
+        stateMachine.transitionTo(RecordState.COMPLETED)
     }
 
     fun setRecording(recording: Boolean) {

--- a/DouyinLite/feature_record/src/test/java/com/app/douyin/pro/feature/record/ui/vm/RecordStateMachineTest.kt
+++ b/DouyinLite/feature_record/src/test/java/com/app/douyin/pro/feature/record/ui/vm/RecordStateMachineTest.kt
@@ -1,0 +1,48 @@
+package com.app.douyin.pro.feature.record.ui.vm
+
+import com.app.douyin.pro.feature.record.ui.state.RecordState
+import org.junit.Assert.*
+import org.junit.Test
+
+class RecordStateMachineTest {
+
+    @Test
+    fun testInitialState() {
+        val stateMachine = RecordStateMachine(RecordState.IDLE) {}
+        assertEquals(RecordState.IDLE, stateMachine.currentState)
+    }
+
+    @Test
+    fun testValidTransitions() {
+        var lastState = RecordState.IDLE
+        val stateMachine = RecordStateMachine(RecordState.IDLE) { lastState = it }
+
+        assertTrue(stateMachine.transitionTo(RecordState.RECORDING))
+        assertEquals(RecordState.RECORDING, stateMachine.currentState)
+        assertEquals(RecordState.RECORDING, lastState)
+
+        assertTrue(stateMachine.transitionTo(RecordState.PAUSED))
+        assertEquals(RecordState.PAUSED, stateMachine.currentState)
+
+        assertTrue(stateMachine.transitionTo(RecordState.RECORDING))
+        assertEquals(RecordState.RECORDING, stateMachine.currentState)
+
+        assertTrue(stateMachine.transitionTo(RecordState.COMPLETED))
+        assertEquals(RecordState.COMPLETED, stateMachine.currentState)
+
+        assertTrue(stateMachine.transitionTo(RecordState.IDLE))
+        assertEquals(RecordState.IDLE, stateMachine.currentState)
+    }
+
+    @Test
+    fun testInvalidTransitions() {
+        val stateMachine = RecordStateMachine(RecordState.IDLE) {}
+
+        assertFalse(stateMachine.transitionTo(RecordState.PAUSED))
+        assertEquals(RecordState.IDLE, stateMachine.currentState)
+
+        stateMachine.transitionTo(RecordState.RECORDING)
+        assertFalse(stateMachine.transitionTo(RecordState.IDLE))
+        assertEquals(RecordState.RECORDING, stateMachine.currentState)
+    }
+}

--- a/DouyinLite/feature_record/src/test/java/com/app/douyin/pro/feature/record/ui/vm/RecordViewModelTest.kt
+++ b/DouyinLite/feature_record/src/test/java/com/app/douyin/pro/feature/record/ui/vm/RecordViewModelTest.kt
@@ -1,0 +1,92 @@
+package com.app.douyin.pro.feature.record.ui.vm
+
+import com.app.douyin.pro.feature.record.domain.usecase.CountdownUseCase
+import com.app.douyin.pro.feature.record.domain.usecase.GetAvailableFiltersUseCase
+import com.app.douyin.pro.feature.record.ui.state.RecordState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+
+@ExperimentalCoroutinesApi
+class RecordViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var viewModel: RecordViewModel
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+
+        // Use real CountdownUseCase as it has no dependencies
+        val countdownUseCase = CountdownUseCase()
+
+        // Manual stub for GetAvailableFiltersUseCase
+        val getAvailableFiltersUseCase = ManualGetAvailableFiltersUseCase()
+
+        viewModel = RecordViewModel(getAvailableFiltersUseCase, countdownUseCase)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun testStartRecording() {
+        viewModel.startRecording()
+        assertEquals(RecordState.RECORDING, viewModel.uiState.value.currentState)
+        assertTrue(viewModel.uiState.value.isRecording)
+    }
+
+    @Test
+    fun testPauseRecording() {
+        viewModel.startRecording()
+        viewModel.pauseRecording("path/to/video.mp4", 5000L)
+
+        assertEquals(RecordState.PAUSED, viewModel.uiState.value.currentState)
+        assertEquals(1, viewModel.uiState.value.segments.size)
+        assertEquals(5000L, viewModel.uiState.value.totalDurationMs)
+        assertEquals("path/to/video.mp4", viewModel.uiState.value.segments[0].filePath)
+    }
+
+    @Test
+    fun testDeleteLastSegment() {
+        viewModel.startRecording()
+        viewModel.pauseRecording("path1.mp4", 3000L)
+        viewModel.startRecording()
+        viewModel.pauseRecording("path2.mp4", 4000L)
+
+        assertEquals(2, viewModel.uiState.value.segments.size)
+        assertEquals(7000L, viewModel.uiState.value.totalDurationMs)
+
+        viewModel.deleteLastSegment()
+
+        assertEquals(1, viewModel.uiState.value.segments.size)
+        assertEquals(3000L, viewModel.uiState.value.totalDurationMs)
+        assertEquals(RecordState.PAUSED, viewModel.uiState.value.currentState)
+
+        viewModel.deleteLastSegment()
+        assertEquals(0, viewModel.uiState.value.segments.size)
+        assertEquals(0L, viewModel.uiState.value.totalDurationMs)
+        assertEquals(RecordState.IDLE, viewModel.uiState.value.currentState)
+    }
+
+    // Manual mock that doesn't use Mockito for the class itself
+    private class ManualGetAvailableFiltersUseCase : GetAvailableFiltersUseCase(
+        com.app.douyin.pro.feature.record.data.RecordRepository(
+            object : com.app.douyin.pro.feature.record.data.source.RecordDataSource {
+                override suspend fun getFilters() = emptyList<com.app.douyin.pro.feature.record.domain.model.FilterEffect>()
+                override suspend fun publishVideo(videoFile: java.io.File, title: String) {}
+            }
+        )
+    )
+}


### PR DESCRIPTION
This PR introduces a multi-segment recording system for the shooting feature, similar to Douyin's core experience.

Key changes:
1. **State Machine**: Introduced `RecordStateMachine` to handle transitions between `IDLE`, `RECORDING`, `PAUSED`, `COMPLETED`, and `ERROR` states.
2. **Data Model**: Established `RecordSegment` to store metadata for each recorded clip.
3. **Timeline Management**: `RecordViewModel` now maintains a list of segments and calculates total duration. It supports deleting the last segment and pausing/resuming recordings.
4. **UI/UX**: Added a `RecordProgressBar` at the top of the shooting screen to visualize recorded segments. Added "Delete" and "Done" buttons.
5. **Editor Integration**: Updated navigation to pass the full segment list to the editor as a JSON string. `EditViewModel` was updated to initialize a multi-clip project from this input.
6. **Testing**: Added unit tests in `RecordStateMachineTest` and `RecordViewModelTest` to ensure logic correctness.

This provides the necessary foundation for advanced editing features and a more flexible shooting experience.

Fixes #90

---
*PR created automatically by Jules for task [5148849886522127581](https://jules.google.com/task/5148849886522127581) started by @zx2121651*